### PR TITLE
Double Ignition Edits, Poke Ignition/Ejection, and Replay Ignition/Ejection

### DIFF
--- a/docs/convention_attribution.md
+++ b/docs/convention_attribution.md
@@ -111,7 +111,7 @@ title: Convention Attribution
 | The Blaze Discard | IAMJEFF
 | The Rank Choice Ejection | IAMJEFF
 | Selfish Focus Inversion | Romain
-| Double Ignition | Libster
+| Trash Double Ignition | Libster
 | The Shadow Finesse | pianoblook
 | The 4 Charm | IAMJEFF
 | The Safety Charm | pianoblook
@@ -122,6 +122,8 @@ title: Convention Attribution
 | The Unknown Dupe Discharge | Indego
 | The Shallow Discard & The Shallow Misplay | Jerry
 | The Unknown Trash Charm | piper
+| Replay Double Ignition & Replay Ejection | Jerry
+| Poke Double Ignition & Poke Ejection | Jerry
 
 <br />
 

--- a/docs/level_19/ejections.md
+++ b/docs/level_19/ejections.md
@@ -14,7 +14,7 @@ title: Ejections
 
 ### Replay Ejection
 
-- First, see the section on *[Replay Double Ignition](level_19/ignitions.md#replay-double-ignition)*.
+- First, see the section on *[Replay Double Ignition](level_19.md#replay-double-ignition)*.
 - Normally, if a player re-clues a card that is globally known as playable, it triggers a *Replay Double Ignition*.
 - However, what if the next player can see that a *Replay Double Ignition* is impossible? In this situation, if the clue-giver is not making a mistake, they instead intend for an *Ejection* on the very next player.
 - In most circumstances, the *Replay Ejection* can not be performed by re-cluing a card in Bob's hand. This is because Bob would first interpret this clue as a *Fix Clue*, which means that the card is actually bad and they should discard it instead of playing it.
@@ -22,7 +22,7 @@ title: Ejections
 
 ### Poke Ejection
 
-- First, see the section on *[Poke Double Ignition](level_19/ignitions.md#poke-double-ignition)*.
+- First, see the section on *[Poke Double Ignition](level_19.md#poke-double-ignition)*.
 - Normally, if a player re-clues globally known trash, it triggers a *Poke Double Ignition*.
 - However, what if the next player can see that a *Poke Double Ignition* is impossible? In this situation, if the clue-giver is not making a mistake, they instead intend for an *Ejection* on the very next player.
 

--- a/docs/level_19/ejections.md
+++ b/docs/level_19/ejections.md
@@ -12,11 +12,19 @@ title: Ejections
 - The *5 Color Ejection* is covered at [level 10](level_10.md#the-5-color-ejection-5ce).
 - This results in a *Signal Shift* from *Play* --> *Save*.
 
-### The Double Play Ejection
+### Replay Ejection
 
-- If a player knows that a card in their hand is playable, and then they receive **another** clue on that card, it is usually a *Fix Clue*, which means that the card is actually bad and they should discard it instead of playing it.
-- However, if this happens on a good card, the other players can see that the clue must have some other purpose - it should signal an *Ejection* on the very next player.
-- This results in a *Signal Shift* from *Fix* --> *Play*.
+- First, see the section on [Replay Double Ignition](ignitions.md#replay-double-ignition)
+- Normally, if a player re-clues a card that is globally known as playable, it triggers a *Replay Double Ignition*.
+- However, what if the next player can see that a Replay Ignition is impossible? In this situation, if the clue-giver is not making a mistake, they instead intend for an *Ejection* on the very next player.
+- In most circumstances, the *Replay Ejection* can not be performed by re-cluing a card in Bob's hand. This is because Bob would first interpret this clue as a *Fix Clue*, which means that the card is actually bad and they should discard it instead of playing it.
+- Note that the *Replay Ejection* is "turned off" in the *End-Game*. This is because players may often re-clue playables to stall in the *End-Game*.
+
+### Poke Ejection
+
+- First, see the section on [Poke Double Ignition](ignitions.md#poke-double-ignition)
+- Normally, if a player re-clues globally known trash, it triggers a *Poke Double Ignition*.
+- However, what if the next player can see that a Replay Ignition is impossible? In this situation, if the clue-giver is not making a mistake, they instead intend for an *Ejection* on the very next player.
 
 ### The Bad Chop Move Ejection (with a Trash Chop Move)
 

--- a/docs/level_19/ejections.md
+++ b/docs/level_19/ejections.md
@@ -16,7 +16,7 @@ title: Ejections
 
 - First, see the section on *[Replay Double Ignition](level_19/ignitions.md#replay-double-ignition)*.
 - Normally, if a player re-clues a card that is globally known as playable, it triggers a *Replay Double Ignition*.
-- However, what if the next player can see that a Replay Ignition is impossible? In this situation, if the clue-giver is not making a mistake, they instead intend for an *Ejection* on the very next player.
+- However, what if the next player can see that a *Replay Double Ignition* is impossible? In this situation, if the clue-giver is not making a mistake, they instead intend for an *Ejection* on the very next player.
 - In most circumstances, the *Replay Ejection* can not be performed by re-cluing a card in Bob's hand. This is because Bob would first interpret this clue as a *Fix Clue*, which means that the card is actually bad and they should discard it instead of playing it.
 - Note that the *Replay Ejection* is "turned off" in the *End-Game*. This is because players may often re-clue playables to stall in the *End-Game*.
 
@@ -24,7 +24,7 @@ title: Ejections
 
 - First, see the section on *[Poke Double Ignition](level_19/ignitions.md#poke-double-ignition)*.
 - Normally, if a player re-clues globally known trash, it triggers a *Poke Double Ignition*.
-- However, what if the next player can see that a Replay Ignition is impossible? In this situation, if the clue-giver is not making a mistake, they instead intend for an *Ejection* on the very next player.
+- However, what if the next player can see that a *Poke Double Ignition* is impossible? In this situation, if the clue-giver is not making a mistake, they instead intend for an *Ejection* on the very next player.
 
 ### The Bad Chop Move Ejection (with a Trash Chop Move)
 

--- a/docs/level_19/ejections.md
+++ b/docs/level_19/ejections.md
@@ -14,7 +14,7 @@ title: Ejections
 
 ### Replay Ejection
 
-- First, see the section on [Replay Double Ignition](ignitions.md#replay-double-ignition)
+- First, see the section on *[Replay Double Ignition](level_19/ignitions.md#replay-double-ignition)*.
 - Normally, if a player re-clues a card that is globally known as playable, it triggers a *Replay Double Ignition*.
 - However, what if the next player can see that a Replay Ignition is impossible? In this situation, if the clue-giver is not making a mistake, they instead intend for an *Ejection* on the very next player.
 - In most circumstances, the *Replay Ejection* can not be performed by re-cluing a card in Bob's hand. This is because Bob would first interpret this clue as a *Fix Clue*, which means that the card is actually bad and they should discard it instead of playing it.
@@ -22,7 +22,7 @@ title: Ejections
 
 ### Poke Ejection
 
-- First, see the section on [Poke Double Ignition](ignitions.md#poke-double-ignition)
+- First, see the section on *[Poke Double Ignition](level_19/ignitions.md#poke-double-ignition)*.
 - Normally, if a player re-clues globally known trash, it triggers a *Poke Double Ignition*.
 - However, what if the next player can see that a Replay Ignition is impossible? In this situation, if the clue-giver is not making a mistake, they instead intend for an *Ejection* on the very next player.
 

--- a/docs/level_19/ignitions.md
+++ b/docs/level_19/ignitions.md
@@ -48,7 +48,7 @@ title: Ignitions
 - If a player is not in a [stall situation](level_6.md#allowable-stall-clues-stall-table) or [stalling for end-game purposes](level_6.md#burning-end-game-stalling), it would be very odd if they give a re-clue a globally known playable card.
 - Indeed, if they are not making a mistake, such a choice must have some other meaning. We agree that the intended meaning of the clue is a *Replay Double Ignition*, meaning that two players should blind-play their *Finesse Position* card.
 - A *Replay Double Ignition* may not pick up new cards.
-- Unlike the *Trash Double Ignition*, the *Replay Double Ignition* may be performed outside of the end-game.  
+- Unlike the *Trash Double Ignition*, the *Replay Double Ignition* may be performed outside of the *End-Game*.  
 - Note that before the *End-Game*, there are often other clues that may be able to get the two cards played. It is ill-advised to attempt a *Replay Double Ignition* if there are other means of getting the cards played. For example, a direct finesse, a sequence of two bluffs, or a double bluff provides additional information and may pick up other good cards.
 
 ### Poke Double Ignition
@@ -56,5 +56,5 @@ title: Ignitions
 - Similar to a *Replay Double Ignition*, if a player is not stalling, it would be very odd if they re-clue a card that is globally known as trash.
 - Indeed, if they are not making a mistake, we agree that the intended meaning of the clue is a *Poke Double Ignition*, meaning that two players should blind-play their *Finesse Position* card.
 - A *Poke Double Ignition* may not pick up new cards. 
-- Like the *Replay Double Ignition*, the *Poke Double Ignition* may be performed outside of the end-game. 
-- In addition, it is not advised to perform the *Poke Double Ignition* if there are other means of getting the cards played.
+- Like the *Replay Double Ignition*, the *Poke Double Ignition* may be performed outside of the *End-Game*. 
+- In addition, it is not advised to perform the *Poke Double Ignition* if there are other means of getting the cards played that provide additional information.

--- a/docs/level_19/ignitions.md
+++ b/docs/level_19/ignitions.md
@@ -9,11 +9,10 @@ title: Ignitions
     - e.g. It doesn't "match", which is unlike a *Finesse*, but like a *Bluff*.
   - unrelated to the *playability* of the clued card
     - e.g. Nothing needs to be "proved" to the player who got clued, which is unlike a *Finesse*, and unlike a *Bluff*.
-- Currently, there is only one type of clue that can cause an *Ignition*; see below.
 
-### Double Ignition (with Known Trash)
+### Trash Double Ignition (with Known Trash)
 
-- Towards the end of the game, if a player clues known trash, then there are usually 3 possible interpretations:
+- Towards the end of the game, if a player clues known trash, then there are usually 2 possible interpretations:
 
 #### 1) A Late-Game Trash Chop Move
 
@@ -29,12 +28,7 @@ title: Ignitions
   - they are not the clue-receiver and they can see that the "pushed" card is bad
   - they are the clue-receiver and they can determine that they are no more cards left to *Trash Push*
 
-#### 3) A Late-Game Burn Clue
-
-- Sometimes, players give meaningless *Burn Clues* to known trash cards in order to avoid drawing more cards. (This is rare, because they would normally re-clue a playable card, but sometimes it is done.)
-- However, players can know that a *Burn Clue* is impossible if they see that a normal *Play Clue* could have been given instead.
-
-#### A Double Ignition
+#### A Trash Double Ignition
 
 - If the known trash clue cannot be any of these 3 things, then it communicates a *Double Ignition*, meaning that two players on the team need to blind-play their *Finesse Position* card as any playable card.
 - In most circumstances, a *Double Ignition* should be clear. This is because the two players with a playable card will each see that the clue giver should have clued the other playable card directly (instead of touching trash).
@@ -48,3 +42,19 @@ title: Ignitions
 
 - Technically, cluing a known trash card to *Chop Move* a "bad" card would trigger an *Ejection* (as a *Bad Trash Chop Move Ejection*).
 - In this situation, players should always assume a *Double Ignition* over a *Bad Trash Chop Move Ejection* (since the latter is very rare).
+
+### Replay Double Ignition 
+
+- If a player is not in a [stall situation](#allowable-stall-clues-stall-table) or [stalling for end-game purposes](#burning-end-game-stalling), it would be very odd if they give a re-clue a globally known playable card.
+- Indeed, if they are not making a mistake, such a choice must have some other meaning. We agree that the intended meaning of the clue is a *Replay Double Ignition*, meaning that two players should blind-play their *Finesse Position* card.
+- A *Replay Double Ignition* may not pick up new cards.
+- Unlike the *Trash Double Ignition*, the *Replay Double Ignition* may be performed outside of the end-game.  
+- Note that before the *End-Game*, there are often other clues that may be able to get the two cards played. It is ill-advised to attempt a *Replay Double Ignition* if there are other means of getting the cards played. For example, a direct finesse, a sequence of two bluffs, or a double bluff provides additional information and may pick up other good cards.
+
+### Poke Double Ignition
+
+- Similar to a *Replay Double Ignition*, if a player is not stalling, it would be very odd if they re-clue a card that is globally known as trash.
+- Indeed, if they are not making a mistake, we agree that the intended meaning of the clue is a *Poke Double Ignition*, meaning that two players should blind-play their *Finesse Position* card.
+- A *Poke Double Ignition* may not pick up new cards. 
+- Like the *Replay Double Ignition*, the *Poke Double Ignition* may be performed outside of the end-game. 
+- In addition, it is not advised to perform the *Poke Double Ignition* if there are other means of getting the cards played.

--- a/docs/level_19/ignitions.md
+++ b/docs/level_19/ignitions.md
@@ -45,7 +45,7 @@ title: Ignitions
 
 ### Replay Double Ignition 
 
-- If a player is not in a [stall situation](#allowable-stall-clues-stall-table) or [stalling for end-game purposes](#burning-end-game-stalling), it would be very odd if they give a re-clue a globally known playable card.
+- If a player is not in a [stall situation](level_6.md#allowable-stall-clues-stall-table) or [stalling for end-game purposes](level_6.md#burning-end-game-stalling), it would be very odd if they give a re-clue a globally known playable card.
 - Indeed, if they are not making a mistake, such a choice must have some other meaning. We agree that the intended meaning of the clue is a *Replay Double Ignition*, meaning that two players should blind-play their *Finesse Position* card.
 - A *Replay Double Ignition* may not pick up new cards.
 - Unlike the *Trash Double Ignition*, the *Replay Double Ignition* may be performed outside of the end-game.  

--- a/docs/level_19/ignitions.md
+++ b/docs/level_19/ignitions.md
@@ -30,18 +30,18 @@ title: Ignitions
 
 #### A Trash Double Ignition
 
-- If the known trash clue cannot be any of these 3 things, then it communicates a *Double Ignition*, meaning that two players on the team need to blind-play their *Finesse Position* card as any playable card.
-- In most circumstances, a *Double Ignition* should be clear. This is because the two players with a playable card will each see that the clue giver should have clued the other playable card directly (instead of touching trash).
-- Sometimes, three players on the team will have playable cards on *Finesse Position*. If a *Double Ignition* is performed in this case, similar to how an *Ambiguous Finesse* works, it will "get" the cards from the final two players. (Bob will do nothing because he sees that the *Double Ignition* is on Cathy and Donald.)
+- If the known trash clue cannot be any of these 3 things, then it communicates a *Trash Double Ignition*, meaning that two players on the team need to blind-play their *Finesse Position* card as any playable card.
+- In most circumstances, a *Trash Double Ignition* should be clear. This is because the two players with a playable card will each see that the clue giver should have clued the other playable card directly (instead of touching trash).
+- Sometimes, three players on the team will have playable cards on *Finesse Position*. If a *Trash Double Ignition* is performed in this case, similar to how an *Ambiguous Finesse* works, it will "get" the cards from the final two players. (Bob will do nothing because he sees that the *Trash Double Ignition* is on Cathy and Donald.)
 
 #### Skipping Bluff Seat
 
-- Rarely, if Bob has a playable card, a *Double Ignition* can skip over Bob and affect Cathy and Donald.
+- Rarely, if Bob has a playable card, a *Trash Double Ignition* can skip over Bob and affect Cathy and Donald.
 
 #### Conflict with Bad Chop Move Ejection
 
 - Technically, cluing a known trash card to *Chop Move* a "bad" card would trigger an *Ejection* (as a *Bad Trash Chop Move Ejection*).
-- In this situation, players should always assume a *Double Ignition* over a *Bad Trash Chop Move Ejection* (since the latter is very rare).
+- In this situation, players should always assume a *Trash Double Ignition* over a *Bad Trash Chop Move Ejection* (since the latter is very rare).
 
 ### Replay Double Ignition 
 

--- a/docs/level_19/ignitions.md
+++ b/docs/level_19/ignitions.md
@@ -30,7 +30,7 @@ title: Ignitions
 
 #### A Trash Double Ignition
 
-- If the known trash clue cannot be any of these 3 things, then it communicates a *Trash Double Ignition*, meaning that two players on the team need to blind-play their *Finesse Position* card as any playable card.
+- If the known trash clue cannot be either of these 2 things, then it communicates a *Trash Double Ignition*, meaning that two players on the team need to blind-play their *Finesse Position* card as any playable card.
 - In most circumstances, a *Trash Double Ignition* should be clear. This is because the two players with a playable card will each see that the clue giver should have clued the other playable card directly (instead of touching trash).
 - Sometimes, three players on the team will have playable cards on *Finesse Position*. If a *Trash Double Ignition* is performed in this case, similar to how an *Ambiguous Finesse* works, it will "get" the cards from the final two players. (Bob will do nothing because he sees that the *Trash Double Ignition* is on Cathy and Donald.)
 

--- a/misc/Deleted_Conventions.md
+++ b/misc/Deleted_Conventions.md
@@ -350,6 +350,13 @@ As we evolve our convention framework, sometimes we decide to delete existing "m
   - Bob sees Cathy blind-play the next red card for seemingly no reason, so he is able to deduce that his slot 2 card is trash.
 - This convention was deleted due to lack of use.
 
+### The Double Play Ejection
+
+- If a player knows that a card in their hand is playable, and then they receive **another** clue on that card, it is usually a *Fix Clue*, which means that the card is actually bad and they should discard it instead of playing it.
+- However, if this happens on a good card, the other players can see that the clue must have some other purpose - it should signal an *Ejection* on the very next player.
+- This results in a *Signal Shift* from *Fix* --> *Play*.
+- This convention was removed in favor of the *Replay Double Ignition* and *Replay Ejection*
+
 <br />
 
 ## Deleted Variant-Specific Conventions

--- a/misc/Deleted_Conventions.md
+++ b/misc/Deleted_Conventions.md
@@ -355,7 +355,7 @@ As we evolve our convention framework, sometimes we decide to delete existing "m
 - If a player knows that a card in their hand is playable, and then they receive **another** clue on that card, it is usually a *Fix Clue*, which means that the card is actually bad and they should discard it instead of playing it.
 - However, if this happens on a good card, the other players can see that the clue must have some other purpose - it should signal an *Ejection* on the very next player.
 - This results in a *Signal Shift* from *Fix* --> *Play*.
-- This convention was removed in favor of the *Replay Double Ignition* and *Replay Ejection*
+- This convention was removed in favor of the *Replay Double Ignition* and *Replay Ejection*.
 
 <br />
 


### PR DESCRIPTION
Renaming Double Ignition to Trash Double Ignition. 
Adding Replay and Poke Double Ignition/Ejection.