### PR TITLE
Short link to early 5 cm

### DIFF
--- a/docs/level-4.md
+++ b/docs/level-4.md
@@ -105,6 +105,8 @@ import ChopMovePrompt from '@site/image-generator/yml/level-4/chop-move-prompt.y
 - Note that the *5's Chop Move* is different than the *Trash Chop Move* in that you can only chop move **one** card with it. Thus, if you clue a 5 and it is **two** (or more) slots away from the chop, then it is to be assumed to be a *Play Clue* on the 5.
   - When counting how far away from chop a card is, you should only look at **unclued** cards.
 - Remember that *5 Stalls* takes precedence over *5's Chop Moves*. Thus, if a number 5 clue **could** just be a *5 Stall* (e.g. it is the *Early Game*), then it should not *Chop Move* anything.
+  - Technically, one could try to analyze whether a clue is a *5 Stall* or *5's Chop Move* by looking at whether the clue-giver had a different clue to give, since *5 Stalls* are only permitted if all "normal" *Play Clues* and *Save Clues* have been extinguished.
+  - However, this analysis relies on asymmetric information, and can be confusing even for experienced players. So, this move is not introduced until [level 17](level-17.md#special-moves).
 
 <br />
 


### PR DESCRIPTION
Re discussion that happened in #convention-questions recently, this is a small pull request that mentions that, yes, early 5cm follows from what's written, but we don't introduce it until a later level.

I didn't include a prescription for what happens if someone clues a 5 one-away from chop during the early game, thinking it best to leave it undefined at level 4. However, I could probably be talked into adding a sentence to say "at level 4, always treat it as a 5 stall" too.