### PR TITLE
Make a grammatical fix

### DIFF
--- a/docs/beginner/minimum-clue-value-principle-question-1.md
+++ b/docs/beginner/minimum-clue-value-principle-question-1.md
@@ -22,7 +22,7 @@ import MinimumClueValuePrincipleQuestion1 from '@site/image-generator/yml/beginn
 
 - Alice is in a special situation where she cannot discard.
 - Bob's blue 4 has been previous touched with a blue clue.
-- Cathy's red 2 and yellow 2 have been previous touched with a number 2 clue.
+- Cathy's red 2 and yellow 2 have previously been touched with a number 2 clue.
 - Enumerate all of the legal *Tempo Clues* that Alice can give.
 
 </TabItem>


### PR DESCRIPTION
"Cathy's red 2 and yellow 2 have been previous touched with a number 2 clue."
"have been previously" would be technically correct.
"have previously been" flows better.
In either case, the suffix "-ly" needs to be added.