### PR TITLE
Clarify wording on 5 Save (should to must)

### DIFF
--- a/docs/beginner/5-save.md
+++ b/docs/beginner/5-save.md
@@ -9,7 +9,7 @@ import FiveSave from '@site/image-generator/yml/beginner/5-save.yml';
 <BeginnersGuideProgress id="5-save" />
 
 - In Hanabi, there is only one copy of each 5. So, we need to stop players from discarding them.
-- We agree that 5's should be saved with **a number 5 clue**. This is called a *5 Save*.
+- We agree that 5's must be saved with **a number 5 clue**. This is called a *5 Save*.
 - In the example below:
   - Alice clues Bob number 5, which touches a single 5 on slot 5.
   - Before this clue, Bob did not have any clued cards in his hand.


### PR DESCRIPTION
Since 5 saves always must happen with the number 5 and never the color, we should update the wording from "should" to "must". This also differentiates it from the (at the moment) identical wording on 2 saves (where "should" is indeed correct).

This is something that confused me when going through the Beginner's Guide and after talking to @Zamiell on Discord, he asked me to create this PR.