### PR TITLE
Fix "clue giver" tag in Save Principle (Question 1)

### DIFF
--- a/image-generator/yml/beginner/save-principle-question-1.yml
+++ b/image-generator/yml/beginner/save-principle-question-1.yml
@@ -7,14 +7,14 @@ stacks:
 discarded:
   - g4
 players:
-  - cards:
-      - type: x
-      - type: x
-      - type: x
-      - type: x
-      - type: x
   - clue_giver: true
     cards:
+      - type: x
+      - type: x
+      - type: x
+      - type: x
+      - type: x
+  - cards:
       - type: b
         clue: b
         middle_note: (1)

--- a/image-generator/yml/beginner/save-principle-question-1.yml
+++ b/image-generator/yml/beginner/save-principle-question-1.yml
@@ -7,8 +7,7 @@ stacks:
 discarded:
   - g4
 players:
-  - clue_giver: true
-    cards:
+  - cards:
       - type: x
       - type: x
       - type: x


### PR DESCRIPTION
Question page: https://hanabi.github.io/docs/beginner/save-principle-question-1

Bob is tagged as clue giver. The question starts with "Alice clues blue to Bob..." and it is now Bobs turn, so Alice should get the clue giver tag. 

This probably happened because the solution is, that Bob needs to clue now (also the tag spoils the answer in a way).

Not sure if I got that yml format correct. Please check before merging