### PR TITLE
Remove extra player in pestilent-double-bluff.yml

### DIFF
--- a/image-generator/yml/level-14/pestilent-double-bluff.yml
+++ b/image-generator/yml/level-14/pestilent-double-bluff.yml
@@ -25,11 +25,6 @@ players:
       - type: x
   - cards:
       - type: x
-      - type: x
-      - type: x
-      - type: x
-  - cards:
-      - type: x
       - type: 2
         clue: 2
         middle_note: (R)


### PR DESCRIPTION
The text accompanying this figure references a four-player game, but the image was a five-player game.