### PR TITLE
Update b5 to y5 in finesse-question-1.yml

### DIFF
--- a/image-generator/yml/beginner/finesse-question-1.yml
+++ b/image-generator/yml/beginner/finesse-question-1.yml
@@ -15,7 +15,7 @@ players:
   - cards:
       - type: b1
         border: false
-      - type: b5
+      - type: y5
       - type: r4
         border: false
       - type: g5


### PR DESCRIPTION
Changing Blue 5 to Yellow 5.
Alternatively could add an explanation of the clues Bob's gotten on the 5s, e.g. "Bob has two unknown 5's previously clued in his hand.", but changing the color is clearer and doesn't confuse the new player.
Or one could make the b5 borderless / not clued.

It's easy to assume the 5s have been clued with a single 5 clue, but you can't know it for sure in the example.
Prompts > finesse, so in case of just "blue" clue earlier (for some odd reason), the finesse couldn't be played like the solution suggests, as the blue unknown card would take priority.