### PR TITLE
Fix unnecessary move link

### DIFF
--- a/docs/examples/unnecessary.mdx
+++ b/docs/examples/unnecessary.mdx
@@ -3,7 +3,7 @@ id: unnecessary
 title: Examples of Unnecessary Moves
 ---
 
-_[Unnecessary Moves](/level-21.mdx)_ are a level 21 convention.
+_[Unnecessary Moves](/level-23.mdx)_ are a level 23 convention.
 
 <br />
 


### PR DESCRIPTION
Unnecessary moves are now level 23, so update the link back.