### PR TITLE
Update trash-touch-elimination.yml

### DIFF
--- a/image-generator/yml/level-16/trash-touch-elimination.yml
+++ b/image-generator/yml/level-16/trash-touch-elimination.yml
@@ -20,11 +20,8 @@ players:
         above: Red 1
         clue: r
       - type: x
-        above: Blue 1
       - type: x
-        above: Green 1
       - type: x
-        above: Yellow 1
   - cards:
       - type: x
         middle_note: r5?

--- a/image-generator/yml/level-16/trash-touch-elimination.yml
+++ b/image-generator/yml/level-16/trash-touch-elimination.yml
@@ -13,15 +13,13 @@ players:
       - type: x
       - type: x
   - cards:
-      - type: r
-        above: Red 4
+      - type: r4
         clue: r
-      - type: r
-        above: Red 1
+      - type: r1
         clue: r
-      - type: x
-      - type: x
-      - type: x
+      - type: b1
+      - type: g1
+      - type: y1
   - cards:
       - type: x
         middle_note: r5?


### PR DESCRIPTION
Double check please but on this picture: https://hanabi.github.io/docs/level-16#trash-touch-elimination I don't believe the b1/g1/y1 part is important.
Clueing 4 here usually is enough fine in a normal game.
So clueing red, except in rare cases should give elimination notes on r5 whatever cards Bob is holding.