### PR TITLE
The Out-of-Order Corollary

### DIFF
--- a/docs/level-19.mdx
+++ b/docs/level-19.mdx
@@ -110,7 +110,7 @@ import OccupiedFinesse from "@site/image-generator/yml/level-19/occupied-finesse
   - Alice clues red to Cathy, touching two cards on slot 1 and slot 2.
   - Bob blind-plays an unrelated card.
   - Cathy marks her slot 1 card as the red 4. (Cathy knows that Alice performed a _Bluff_ and slot 1 was the focus of the clue.)
-  - Cathy also marks her slot 2 card as the red 5. (Cathy knows that if it was a red 3, then Bob would be forced to give a _Fix Clue_.)
+  - Cathy also marks her slot 2 card by default as the red 5. (Cathy knows that if it is a red 3, then a _Fix Clue_ will happen later.)
 
 <br />
 


### PR DESCRIPTION
If someone has r4-r3-x-x-x with r3 playable, and he receives a red clue, it's still possible that it is a bluff, if the 3 clue is available and clear.