### PR TITLE
The Double Ejection

### DIFF
--- a/docs/convention-attribution.mdx
+++ b/docs/convention-attribution.mdx
@@ -37,7 +37,7 @@ title: Convention Attribution
 | The Elimination Riding Deduction                                    | Duneaught                           |
 | The Free Choice Finesse                                             | Hyphen-ated                         |
 | The Trash Push                                                      | Duneaught                           |
-| The Trash Bluff                                                     | Duneaught & Zamiel & IAMJEFF        |
+| The Trash Bluff                                                     | Duneaught & Zamiel                  |
 | The Trash Finesse                                                   | Duneaught                           |
 | The Trash Push Finesse                                              | Duneaught                           |
 | The Hesitation Blind-Play                                           | Zamiel                              |
@@ -107,7 +107,7 @@ title: Convention Attribution
 | The 5 Number Discharge                                              | IAMJEFF                             |
 | The Blaze Discard                                                   | IAMJEFF                             |
 | The Rank Choice Ejection                                            | IAMJEFF                             |
-| The Trash Double Ignition                                           | Libster                             |
+| The Trash Double Ignition                                           | Libster & IAMJEFF                   |
 | The Shadow Finesse                                                  | pianoblook                          |
 | The 4 Charm                                                         | IAMJEFF                             |
 | Unnecessary Principles                                              | Floriman & Kakashi                  |
@@ -123,6 +123,7 @@ title: Convention Attribution
 | The 1's Junk Discharge                                              | piper                               |
 | The 1's Junk Charm                                                  | pianoblook                          |
 | Always Loaded Principle                                             | Lel0uch                             |
+| The Double Ejection                                                 | IAMJEFF                             |
 
 <br />
 

--- a/docs/extras/ejection-extentions.mdx
+++ b/docs/extras/ejection-extentions.mdx
@@ -69,19 +69,20 @@ These are additional rules that can apply to _Ejections_, _Discharges_, and _Cha
 
 ### The Double Ejection
 
-- If a _Play Clue_ and an _Ejection_ are both possible and have the same efficiency, players are always expected to give a direct _Play Clue_. (We want to keep things simple and reduce the vector for mistakes to happen.)
+- If a _Play Clue_ and an _Ejection_ are both possible as a 1-for-1, players are always expected to give a direct _Play Clue_. (We want to keep things simple and reduce the vector for mistakes to happen.)
 - What happens if a player breaks this rule and does an _Ejection_ anyway? They must be trying to send an additional message.
 - After Bob _Ejects_ in this situation, Cathy is expected to know that Alice really intended for a _Double Ejection_. Here, Cathy should also play her _Second Finesse Position_.
-- Note that if Cathy's _Finesse Position_ is a playable or a one-away card, Bob would just blind-play his _Finesse Position_ as a _Double Ignition_ in the first place. In this situation, the _"Unnecessary"_ component for Cathy shifts by one slot, which is the reason this move calls for a _Double Ejection_.
 - For example, in a 4-player game:
-  - Red 1 is played on the stacks. 
-  - Donald has a known red 2 which has been clued earlier.
-  - Alice gives a red clue to Donald, touching a red 2.
-  - Bob sees that Alice recluing a globally known red 2 for no reason, she must be trying to communicate something extra - a _Replay Ejection_. Thus, Bob blind-plays his _Second Finesse Position_, and a blue 1 is successfully played.
-  - Now, it is Cathy's turn. Cathy knows that Bob _Ejected_ a blue 1 from the red clue. But wait! Blue 1 was not blocked and Alice could just simply give a direct _Play Clue_ on it. Doing a _Replay Ejection_ doesn't make any sense. Alice must be trying to send a deeper message - the move is sort of _Unnecessary_.
-  - However, if Cathy has a playable card or a one-away card on her _Finesse Position_, Bob would just blind-play his _Finesse Position_ as a _Replay Double Ignition_ rather than _Ejecting_. Which implies Bob can see that a _Replay Double Ignition_ is impossible.
-  - Thus, Cathy blind-plays her _Second Finesse Position_ as a _Double Ejection_, and a blue 2 is successfully played.
+  - Red 1 is played on the stacks.
+  - Donald has a globally-known red 2 in his hand. (It was given a _Play Clue_ earlier with a number 2 clue.)
+  - Alice gives a red clue to Donald, filling in the 2 as a red 2.
+  - Bob sees that since the red 2 was _already_ going to play on the stacks, Alice must be trying to communicate something extra. Normally, Bob would think that this is a _Replay Double Ignition_. However, it can't be that, because Cathy has a red 1 on her _Finesse Position_, which is trash.
+  - Thus, Bob knows that Alice must be intend for a _Replay Ejection_ instead. Bob blind-plays his _Second Finesse Position_. It is a blue 1 and successfully plays.
+  - Just like Bob, Cathy is able to see that Alice's clue was a _Replay Ejection_. However, Cathy also notices that blue 1 was not blocked, meaning that Alice could just given a blue clue to Bob as a direct _Play Clue_. Doing a _Replay Ejection_ in this situation does not make any sense.
+  - Cathy knows that in this situation, Alice is intending for a _Double Ejection_. Cathy blind-plays her _Second Finesse Position_. It is a blue 2 and successfully plays.
 
 <DoubleEjection />
+
+- Situations that call for _Double Ejections_ are very similar to situations that call for _Double Ignitions_. Notice that if Cathy's _Finesse Position_ is a playable or a one-away-from-playable card, Alice's _Double Ejection_ would not work: Bob would blind-play his _Finesse Position_ as a _Double Ignition_. However, since Cathy does not have a playable, Bob thinks to himself: "Even though this clue is pretty weird, Alice is probably just doing an _Ejection_ as a 1-for-1 here because I have some blocking card in my hand." After Bob blind-plays his _Second Finesse Position_, Cathy sees that the move was _Unnecessary_. But unlike a normal _Unnecessary_ move (where Cathy would be expected to blind-play her _Finesse Position_ card), here Cathy knows that it makes more sense to blind-play her _Second Finesse Position_ card (since her _First Finesse Position_ card must be unplayable).
 
 <br />

--- a/docs/extras/ejection-extentions.mdx
+++ b/docs/extras/ejection-extentions.mdx
@@ -63,3 +63,12 @@ These are additional rules that can apply to _Ejections_, _Discharges_, and _Cha
 
 - First, see the section on _[Stacked Ejection](#the-stacked-ejection)_.
 - Just like _Stacked Ejection_, it is possible to do a _Stacked Discharge_ or a _Stacked Charm_ in the exact same way.
+
+<br />
+
+### The Double Ejection
+
+- If a _Play Clue_ and an _Ejection_ are both possible and have the same efficiency, players are always expected to give a direct _Play Clue_. (We want to keep things simple and reduce the vector for mistakes to happen.)
+- What happens if a player breaks this rule and does an _Ejection_ anyway? They must be trying to send an additional message.
+- After Bob _Ejects_ in this situation, Cathy is expected to know that Alice really intended for a _Double Ejection_. Here, Cathy should also play her _Second Finesse Position_.
+- Note that if Cathy's _Finesse Position_ is a playable or a one-away card, Bob would just blind-play his _Finesse Position_ as a _Double Ignition_ in the first place. In this situation, the _"Unnecessary"_ component for Cathy shifts by one slot, which is the reason this move calls for a _Double Ejection_.

--- a/docs/extras/ejection-extentions.mdx
+++ b/docs/extras/ejection-extentions.mdx
@@ -5,6 +5,7 @@ title: Ejection Extensions
 
 import OutOfPositionEjection from "@site/image-generator/yml/extras/ejection-extensions/out-of-position-ejection.yml";
 import StackedEjection from "@site/image-generator/yml/extras/ejection-extensions/stacked-ejection.yml";
+import DoubleEjection from "@site/image-generator/yml/extras/ejection-extensions/double-ejection.yml";
 
 These are additional rules that can apply to _Ejections_, _Discharges_, and _Charms_.
 
@@ -72,3 +73,7 @@ These are additional rules that can apply to _Ejections_, _Discharges_, and _Cha
 - What happens if a player breaks this rule and does an _Ejection_ anyway? They must be trying to send an additional message.
 - After Bob _Ejects_ in this situation, Cathy is expected to know that Alice really intended for a _Double Ejection_. Here, Cathy should also play her _Second Finesse Position_.
 - Note that if Cathy's _Finesse Position_ is a playable or a one-away card, Bob would just blind-play his _Finesse Position_ as a _Double Ignition_ in the first place. In this situation, the _"Unnecessary"_ component for Cathy shifts by one slot, which is the reason this move calls for a _Double Ejection_.
+
+<DoubleEjection />
+
+<br />

--- a/docs/extras/ejection-extentions.mdx
+++ b/docs/extras/ejection-extentions.mdx
@@ -73,6 +73,14 @@ These are additional rules that can apply to _Ejections_, _Discharges_, and _Cha
 - What happens if a player breaks this rule and does an _Ejection_ anyway? They must be trying to send an additional message.
 - After Bob _Ejects_ in this situation, Cathy is expected to know that Alice really intended for a _Double Ejection_. Here, Cathy should also play her _Second Finesse Position_.
 - Note that if Cathy's _Finesse Position_ is a playable or a one-away card, Bob would just blind-play his _Finesse Position_ as a _Double Ignition_ in the first place. In this situation, the _"Unnecessary"_ component for Cathy shifts by one slot, which is the reason this move calls for a _Double Ejection_.
+- For example, in a 4-player game:
+  - Red 1 is played on the stacks. 
+  - Donald has a known red 2 which has been clued earlier.
+  - Alice gives a red clue to Donald, touching a red 2.
+  - Bob sees that Alice recluing a globally known red 2 for no reason, she must be trying to communicate something extra - a _Replay Ejection_. Thus, Bob blind-plays his _Second Finesse Position_, and a blue 1 is successfully played.
+  - Now, it is Cathy's turn. Cathy knows that Bob _Ejected_ a blue 1 from the red clue. But wait! Blue 1 was not blocked and Alice could just simply give a direct _Play Clue_ on it. Doing a _Replay Ejection_ doesn't make any sense. Alice must be trying to send a deeper message - the move is sort of _Unnecessary_.
+  - However, if Cathy has a playable card or a one-away card on her _Finesse Position_, Bob would just blind-play his _Finesse Position_ as a _Replay Double Ignition_ rather than _Ejecting_. Which implies Bob can see that a _Replay Double Ignition_ is impossible.
+  - Thus, Cathy blind-plays her _Second Finesse Position_ as a _Double Ejection_, and a blue 2 is successfully played.
 
 <DoubleEjection />
 

--- a/image-generator/yml/extras/ejection-extensions/double-ejection.yml
+++ b/image-generator/yml/extras/ejection-extensions/double-ejection.yml
@@ -1,32 +1,35 @@
 stacks:
   - r: 1
-  - y: 0
-  - g: 0
-  - b: 0
-  - p: 0
+  - y: 1
+  - g: 1
+  - b: 1
+  - p: 1
 players:
   - clue_giver: true
-  - cards:
-      - type: x
-      - type: x
-      - type: x
-      - type: x
     cards:
       - type: x
       - type: x
-        above: Blue 1
-      - type: x
-      - type: x
-  - cards:
-      - type: Red 1
-      - type: x
-        above: Green 1
       - type: x
       - type: x
   - cards:
       - type: x
-      - type: r
-        clue: 2
+      - type: 5
+      - type: 5
+      - type: 5
+  - text: Bob discards
+  - name: Cathy
+    cards:
+      - type: x
+      - type: x
         above: Red 2
       - type: x
       - type: x
+  - name: Donald
+    cards:
+      - type: x
+        clue: r
+        above: Red 5
+        middle_note: 5
+      - type: x
+      - type: x
+      - type: r1

--- a/image-generator/yml/extras/ejection-extensions/double-ejection.yml
+++ b/image-generator/yml/extras/ejection-extensions/double-ejection.yml
@@ -12,27 +12,26 @@ players:
       - type: x
       - type: x
   - cards:
-      - type: x
-        above: Red 4
-      - type: x
-        above: Blue 1
-      - type: x
-        above: Red 3
-      - type: x
-        above: Red 2
+      - type: r1
+        border: false
+      - type: b1
+        border: false
+      - type: g4
+        border: false
+      - type: g4
+        border: false
   - name: Cathy
     cards:
-      - type: x
-        above: Red 1
-      - type: x
-        above: Blue 2
+      - type: r1
+        border: false
+      - type: b2
+        border: false
       - type: x
       - type: x
   - name: Donald
     cards:
-      - type: 2
+      - type: r2
         clue: r
-        # middle_note: 2
       - type: x
       - type: x
       - type: x

--- a/image-generator/yml/extras/ejection-extensions/double-ejection.yml
+++ b/image-generator/yml/extras/ejection-extensions/double-ejection.yml
@@ -1,9 +1,9 @@
 stacks:
   - r: 1
-  - y: 1
-  - g: 1
-  - b: 1
-  - p: 1
+  - y: 0
+  - g: 0
+  - b: 0
+  - p: 0
 players:
   - clue_giver: true
     cards:
@@ -13,23 +13,26 @@ players:
       - type: x
   - cards:
       - type: x
-      - type: 5
-      - type: 5
-      - type: 5
-  - text: Bob discards
+        above: Red 4
+      - type: x
+        above: Blue 1
+      - type: x
+        above: Red 3
+      - type: x
+        above: Red 2
   - name: Cathy
     cards:
       - type: x
+        above: Red 1
       - type: x
-        above: Red 2
+        above: Blue 2
       - type: x
       - type: x
   - name: Donald
     cards:
-      - type: x
+      - type: 2
         clue: r
-        above: Red 5
-        middle_note: 5
+        # middle_note: 2
       - type: x
       - type: x
-      - type: r1
+      - type: x

--- a/image-generator/yml/extras/ejection-extensions/double-ejection.yml
+++ b/image-generator/yml/extras/ejection-extensions/double-ejection.yml
@@ -1,0 +1,32 @@
+stacks:
+  - r: 1
+  - y: 0
+  - g: 0
+  - b: 0
+  - p: 0
+players:
+  - clue_giver: true
+  - cards:
+      - type: x
+      - type: x
+      - type: x
+      - type: x
+    cards:
+      - type: x
+      - type: x
+        above: Blue 1
+      - type: x
+      - type: x
+  - cards:
+      - type: Red 1
+      - type: x
+        above: Green 1
+      - type: x
+      - type: x
+  - cards:
+      - type: x
+      - type: r
+        clue: 2
+        above: Red 2
+      - type: x
+      - type: x


### PR DESCRIPTION
- Adding **The Double Ejection** section
- Updating **Convention Attribution**
  - Adding myself to the attribution of the *Double Ejection*.
  - Removing myself from the attribution of the *Trash Bluff*. It's because Zamiel added me to the list when I invented *Trash Double Bluff* (which has been deleted in favor of *Trash Double Ignition*) and changed some definition of the *Trash Bluff*. But I don't think I deserved it.
  - Instead, I added myself to the attribution of *Trash Double Ignition*. It's because my *Trash Double Bluff* is literally a *Trash Double Ignition* and I think I deserve it.