### PR TITLE
Clarified definition of trash in BCME

### DIFF
--- a/docs/extras/ejections.mdx
+++ b/docs/extras/ejections.mdx
@@ -35,6 +35,7 @@ import RankChoice from "@site/image-generator/yml/extras/ejections/rank-choice.y
 - In this situation, it should signal an _Ejection_ on the very next player.
 - This results in a _Signal Shift_ from _Save_ --> _Trash_.
 - **Any** move that results in a _Chop Move_ can be used to initiate such an _Ejection_.
+- Duplicated cards can be chop moved for distribution purposes and should not be considered as  _Chop Moving_ trash.
 - _Bad Chop Move Ejections_ can be performed throughout the game. (But keep in mind that in the _End-Game_, a player might just be stalling.)
 
 <br />


### PR DESCRIPTION
Added a clarification that chop moving duplicates should be allowed and should not call for a BCME when it can be for distribution purposes.