### PR TITLE
Update good-touch-principle-question-1.yml

### DIFF
--- a/image-generator/yml/beginner/good-touch-principle-question-1.yml
+++ b/image-generator/yml/beginner/good-touch-principle-question-1.yml
@@ -4,6 +4,8 @@ stacks:
   - g: 5
   - b: 2
   - p: 1
+discarded:
+  - b3
 players:
   - clue_giver: true
     cards:


### PR DESCRIPTION
According to the solution, Alice _needs_ to clue the b3:

https://github.com/hanabi/hanabi.github.io/blob/c3d0bc4c77ff771e32a4c78fb884139795cdaef6/docs/beginner/good-touch-principle-question-1.mdx?plain=1#L28

But this seems to be making a lot of assumptions about what else is happening in the game.

Adding the b3 to the discard pile so that she genuinely _needs_ to clue it.