### PR TITLE
Incorrect clue recipient listed in example

### DIFF
--- a/docs/level-11.mdx
+++ b/docs/level-11.mdx
@@ -233,7 +233,7 @@ import CluingOnes3 from "@site/image-generator/yml/level-11/cluing-ones-3.yml";
   - Donald is holding a cluable red 2.
   - Alice would like to get the red 1 and the blue 1 played. (No-one else has a red 1 or a blue 1.) Should she clue 1, red, or blue?
   - Just like in the previous example, cluing number 1 means that the red 2 will have to be clued as a 1-for-1, which results in an efficiency of 3-for-2.
-  - Instead, Alice clues blue to Donald as a 2-for-1. Next, Bob will clue red to Donald, performing the _Finesse_ as a 2-for-1. In total, this is a 4-for-2.
+  - Instead, Alice clues blue to Cathy as a 2-for-1. Next, Bob will clue red to Donald, performing the _Finesse_ as a 2-for-1. In total, this is a 4-for-2.
 
 <CluingOnes2 />
 


### PR DESCRIPTION
Updated the last bullet of Example 2 of "Cluing 1's in the early game" to the correct clue recipient for Alice (was written Donald, should be Cathy)

Unless this was a meta-joke about using context to interpret the given text. =)