### PR TITLE
Fix links in about.mdx

### DIFF
--- a/docs/about.mdx
+++ b/docs/about.mdx
@@ -13,7 +13,7 @@ Have you found your way here from the Internet? That's fine too. Feel free to ch
 
 ### Other Quick Links
 
-- [The rules of the game](https://github.com/Zamiell/hanabi-live/blob/master/docs/RULES.mdx) (written)
+- [The rules of the game](https://github.com/hanabi/hanabi.github.io/blob/main/misc/rules.md) (written)
 - [The rules of the game](https://www.youtube.com/watch?v=VrFCekQb4nY) (video)
 - [Hanab Live](https://hanab.live) (the best place to play online)
 - [Board Game Arena](http://boardgamearena.com) (not as good as Hanab Live, but has a good number of players)
@@ -31,4 +31,4 @@ Have you found your way here from the Internet? That's fine too. Feel free to ch
 
 ### Contributing
 
-If you want to contribute to this website, then see the [README.md](https://github.com/hanabi/hanabi.github.io/blob/main/README.mdx) for the repository and [the documentation on how to create example images](image-format.mdx).
+If you want to contribute to this website, then see the [README.md](https://github.com/hanabi/hanabi.github.io/blob/main/README.md) for the repository and [the documentation on how to create example images](image-format.mdx).


### PR DESCRIPTION
The links pointing to the rules of Hanabi and the GitHub repo's README were outdated.