### PR TITLE
Fix Level 7 Challenge Question 1

### DIFF
--- a/docs/challenge-questions/level-7.mdx
+++ b/docs/challenge-questions/level-7.mdx
@@ -24,7 +24,7 @@ These questions are for [level 7](../level-7) strategies.
   ]}>
 <TabItem value="question">
 
-- There are 4 cards left in the deck, and no clues available. All remaining useful cards are gotten.
+- There are 3 cards left in the deck, and no clues available. All remaining useful cards are gotten.
 - Bob knows the identity of all of his clued cards.
 - What action should Alice perform?
 


### PR DESCRIPTION
[Relevant link.](https://hanabi.github.io/docs/challenge-questions/level-7)

We change the number of cards left in the deck from 4 to 3.

The solution says Alice must discard; this is unnecessary and it is more straightforward for Alice to just play. Let's look at how the game would play out.

- 0 clues, 4 cards to play, 4 cards in deck: Alice plays
- 0 clues, 3 cards to play, 3 cards in deck: Bob plays
- 1 clue, 2 cards to play, 2 cards in deck: Cathy stalls
- 0 clues, 2 cards to play, 2 cards in deck: Alice discards
- 1 clue, 2 cards to play, 1 cards in deck: Bob plays

Now everyone gets their final turn, which is fine because Bob only has one more card to play.

This example is easily fixable. Let's say we put 3 cards left in the deck instead of 4:

- 0 clues, 4 cards to play, 3 cards in deck: Alice discards
- 1 clue, 4 cards to play, 2 cards in deck: Bob plays
- 2 clues, 3 cards to play, 1 card in deck: Cathy stalls
- 1 clue, 3 cards to play, 1 card in deck: Alice stalls
- 0 clues, 3 cards to play, 1 card in deck: Bob plays
- 1 clue, 2 cards to play, 0 cards in deck. Cathy's turn

Now each player takes their final turn, and Alice plays r4 with Bob playing r5 immediately afterwards.

To check that this is necessary, let's say Alice plays:

- 0 clues, 4 cards to play, 3 cards in deck: Alice plays
- 0 clues, 3 cards to play, 2 cards in deck: Bob plays
- 1 clue, 2 cards to play, 1 cards in deck: Cathy stalls
- 0 clues, 2 cards to play, 1 cards in deck: Alice discards

Then the final turn would initiate with Bob having 2 cards left to play. The team loses.