### PR TITLE
Fix Ex 3 of Unnecessary Moves with Unknown Trash Off Chop

### DIFF
--- a/docs/level-23.mdx
+++ b/docs/level-23.mdx
@@ -74,7 +74,7 @@ import UnnecessaryBadChopMoveEjection from "@site/image-generator/yml/level-23/u
 #### Example 3 - An Unnecessary Unknown Trash Discharge (with a Bad Chop Move Ejection)
 
 - For example, in a 4-player game:
-  - All the 2's are played on the stacks.
+  - All the 2's are played on the stacks except for the blue 2.
   - Donald's hand is as follows: `blue 4, blue 4, red 1, blue 1`
   - Alice clues red to Donald, touching the red 1 on slot 3.
   - Bob sees that this is an _Unknown Trash Discharge_. He plays his _Third Finesse Position_. It is a blue 2 and it successfully plays.


### PR DESCRIPTION
The example has b2 play when b2 is already played on the stacks. Fixes by making b2 not yet played on the stack.