### PR TITLE
Issue #1045: Rename the Taffy Double Bluff, and update the language in Taffy Bluff

### DIFF
--- a/docs/variant-specific/pink.mdx
+++ b/docs/variant-specific/pink.mdx
@@ -278,6 +278,20 @@ These conventions apply to any variant with a pink (touched by all ranks) suit.
 - In this situation, if there is no other possible interpretation for the clue other than a _Bubblegum Prompt_ or a _Bubblegum Finesse_, and it is unlikely for the cluer to be making a mistake, then the target slot should "slide" to the right.
 - If the slot immediately to the right is also impossible to be a pink card, then it should continue to slide right until it finds a pink card, wrapping around to the other side of the hand if necessary.
 
+### The Pestilent Bubblegum Double Bluff
+
+- Similar to a _Bubblegum Finesse_ on a _two-away-from-playable_ pink card, it is possible to perform a _Pestilent Bubblegum Double Bluff_.
+- For example, in a 4-player game:
+  - It is the first turn and nothing is played on the stacks.
+  - Alice clues number 4 to Donald, touching a pink 3 on slot 5.
+  - Bob knows that Alice is violating _Pink Promise_. This must mean that he is supposed to play his slot 4 card as pink 1, with pink 2 promised as playable through his current finesse position.
+  - Bob blind-plays slot 4 and it is a pink 1.
+  - Cathy sees that Bob was not holding pink 2 when Alice gave the clue, so Cathy must have pink 2 on her finesse position.
+  - Cathy blind-plays slot 1 and it is a blue 1.
+  - Donald realizes that if his clued card was a pink 2, then Cathy would not have done anything. Thus, this must have been a _Pestilent Bubblegum Double Bluff_. Donald updates the note on his card to be a pink 3.
+  - After two blind plays, the team agrees that no one is promised pink 2.
+- This used to be called a _Taffy Double Bluff_, but the term was phased out because the logic behind this move is closer to a _Pestilent Double Bluff_ than a _Taffy Bluff_.
+
 <br />
 
 ## Level 21 - Other Special Moves
@@ -321,35 +335,25 @@ These conventions apply to any variant with a pink (touched by all ranks) suit.
 
 ### The Taffy Bluff
 
-- First, see the section on the _[Bubblegum Bluff](#the-bubblegum-bluff)_.
-- A _Bubblegum Bluff_ is when _Pink Promise_ is violated on a _one-away-from-playable_ pink card to perform a _Bluff_.
-- It is also permissible to violate _Pink Promise_ on a _two-away-from-playable_ pink card to perform a _Bluff_. This is called a _Taffy Bluff_ to distinguish it from the former case.
+- First, see the sections on the _[Bubblegum Finesse](#the-bubblegum-prompt--the-bubblegum-finesse)_ and the _[Bubblegum Bluff](#the-bubblegum-bluff)_.
+- _Bubblegum_ moves rely on misrepresenting the identity of a card to compel a player to play from a slot other than their finesse position.
+- By their nature, it is impossible to give a _Bubblegum_ clue to a _one-away-from-playable_ pink card using its own number.
+- (Cluing 3 to a _one-away-from-playable_ pink 3 will result in a blind-play from finesse position, not from a non-finesse slot 3.)
+- However, what happens if the blind-played _"Bubblegum" Bluff_'s position actually matches the number of a _one-away-from-playable_ pink?
+- Then the clue-receiver can be sure that their pink card is not _one-away-from-playable_. (Conventionally, we agree it is _two-away-from-playable_.)
+- This is called a _Taffy Bluff_ to distinguish it from a _Bubblegum Bluff_.
 - For example, in a 3-player game:
   - It is the first turn and nothing is played on the stacks.
-  - Alice clues number 2 to Cathy, touching a pink 3 on slot 5. (The pink 3 is _two-away-from-playable_.)
+  - Alice clues number 2 to Cathy, touching a pink 3 on slot 3. (The pink 3 is currently _two-away-from-playable_.)
   - Bob knows that Alice is violating _Pink Promise_.
   - If he plays slot 1, then Alice will mark it as the matching 2 and will misplay it.
-  - Thus, this must be a _Bubblegum Double Finesse_, meaning that Bob should play the slot that matches the rank that Alice chose.
+  - Thus, this must be a _Bubblegum Double Finesse_, meaning that Bob should first play the slot that matches the rank that Alice chose.
   - Bob tries to blind-play pink 1 from slot 2, but it is a red 1 instead. It is now revealed to Bob that this was a _Taffy Bluff_ instead of a _Bubblegum Double Finesse_.
   - Cathy knows that if her clued card was really a 2, Bob would have played slot 1. Thus, it cannot be a 2. Furthermore, there are no _Ejections_ that match this situation, so this must be a _Taffy Bluff_ on a pink 3.
 - It is also possible to perform a _Taffy Bluff_ with cards other than a pink 3. For example:
   - A _two-away-from-playable_ pink 4 that is clued with a number 3 clue would cause a blind-play from slot 3.
   - A _two-away-from-playable_ pink 5 that is clued with a number 4 clue would cause a blind-play from slot 4.
-- _Bubblegum Bluffs_ have precedence over _Taffy Bluffs_. In other words, you are only supposed to assume a _Taffy Bluff_ if a _Bubblegum Bluff_ is impossible.
-
-### The Taffy Double Bluff
-
-- First, see the section on the [Taffy Bluff](#the-taffy-bluff).
-- Rarely, a player can perform a _Taffy Double Bluff_ by violating _Pink Promise_ on a _three-away-from-playable_ pink card.
-- For example, in a 4 player game:
-  - It is the first turn of the game and nothing is played on the stacks.
-  - Alice clues number 4 to Donald, touching a pink 3 on slot 3.
-  - Bob knows that since Alice violated _Pink Promise_, this must be some sort of _Bubblegum_ move.
-  - Bob blind-plays his slot 4 card. It is a red 1 and it successfully plays on to the stacks.
-  - From Donald's perspective, he knows that Alice performed a _Bubblegum Bluff_. Donald marks his slot 3 card as a pink 2 (the pink card that is _one-away-from-playable_).
-  - Next, it is Cathy's turn. Cathy sees that Donald will mark his pink card as a pink 2. However, the card is really a pink 3, so the situation has not yet resolved.
-  - Cathy blind-plays her slot 1 card. It is a red 2 and it successfully plays on the stacks.
-  - Donald realizes that if his clued card was a pink 2, then Cathy would not have done anything. Thus, this must have been a _Taffy Double Bluff_. Donald updates the note on his card to be a pink 3 (the pink card that is _two-away-from-playable_).
+- Note that it is impossible for a clue to be a _Bubblegum Bluff_ and a _Taffy Bluff_ at the same time.
 
 <br />
 


### PR DESCRIPTION
The logic behind a Taffy Double Bluff is much closer to that behind a Bubblegum Finesse or a Pestilent Double Bluff. We are renaming it as such.

The description for Taffy Bluff was not logically motivating and, as such, could be hard for first-time readers to understand. (I know I struggled with understanding it...) I'm hoping the new rewording makes it more intuitive.