### PR TITLE
Update null 5s chop move to include playable

### DIFF
--- a/docs/variant-specific/null.mdx
+++ b/docs/variant-specific/null.mdx
@@ -51,7 +51,7 @@ These conventions apply to any variant with a null (touched by no clues) suit. T
 
 - When Alice gives a number 5 clue that is not a _5 Save_ or a _5's Chop Move_, **as long as Bob is not loaded**, it signals a _Null 5 Chop Move_ on Bob.
   - Note that the number 5 clue can be given to any player; it does not necessarily have to be on Bob.
-- The _Null 5 Chop Move_ is **only** allowed to save null cards that are critical (or a null 2 that isn't visible elsewhere, same as an ordinary _2 Save_).
+- The _Null 5 Chop Move_ is **only** allowed to save null cards that are playable / phantom playable or critical (or a null 2 that isn't visible elsewhere, same as an ordinary _2 Save_).
 - This convention applies only to Bob; see _The Double Save_ for saving other players.
 
 #### The Loaded 5 Null Play Clue


### PR DESCRIPTION
Update the null 5s chop move to include playable + phantom playable cards. Based on discussion seemed like there was agreement of those who participated that being able to 5s chop move a playable card or phantom playable card is beneficial with 5s null chop move. Open to additional input why we want to restrict it specifically to criticals.