### PR TITLE
Update level-4.mdx

### DIFF
--- a/docs/level-4.mdx
+++ b/docs/level-4.mdx
@@ -171,6 +171,7 @@ import ChopMovePrompt from "@site/image-generator/yml/level-4/chop-move-prompt.y
 <ChopMoveNew />
 
 - The exception to the above rule is if a clue is given that touches a _Chop Moved_ card for the first time and only "old" cards are touched.
+- In this case, the focus is on the left-most _Chop Moved_ card that was touched by the clue.
 - For example, in a 3-player game of the rainbow variant:
   - All the 2's are played on the stacks.
   - Bob has an unknown red card on slot 3, an unknown red card on slot 4, and a _Chop Moved_ card in slot 5 (that is completely unclued).


### PR DESCRIPTION
Clarifies the "exception" to "chop moves and new clues" when the clue touches only old cards.