### PR TITLE
Trash card does not end the early game (lvl 2)

### DIFF
--- a/docs/level-2.mdx
+++ b/docs/level-2.mdx
@@ -140,6 +140,7 @@ import WrongPrompt from "@site/image-generator/yml/level-2/wrong-prompt.yml";
 - Players should generally avoid "touching" trash cards with a clue, as doing so would violate _Good Touch Principle_.
   - Rarely, it can be useful to deliberately clue a trash card and violate _Good Touch Principle_ in order to perform a special move. Several such moves are covered later on.
 - In the case where a suit is partially "dead", the unneeded cards are also considered trash. For example, if both copies of the red 3 have been discarded, then the red 4 and the red 5 are both considered trash.
+- Discarding known trash cards does not end the early game.
 
 <br />
 


### PR DESCRIPTION
Added in the definition of trash that discarding trash card does not end the early game, as this does not seem to be present anywhere in the doc. It could be clearer in the "early game section" of lvl 1, but at this point the notion of "trash card" is not introduced.