### PR TITLE
Update muddy-rainbow-cocoa-rainbow.mdx

### DIFF
--- a/docs/variant-specific/muddy-rainbow-cocoa-rainbow.mdx
+++ b/docs/variant-specific/muddy-rainbow-cocoa-rainbow.mdx
@@ -30,7 +30,7 @@ These conventions apply to any variant with a muddy rainbow suit or a cocoa rain
 - In variants with a pink suit, the _[Pink Choice Tempo Clue](pink.mdx#the-pink-choice-tempo-clue)_ convention is "turned on", since players often have a _Free Choice_ with how they can clue pink cards. Muddy rainbow has a similar convention.
 - When one or more muddy rainbow cards are retouched with a color clue, and there are no "new" cards introduced (or, if the only "new" cards introduced are trash), then extra information can be conveyed by what color is chosen. The color chosen should correspond to the slot that they should play.
 - This is called a _Muddy Rainbow Choice Tempo Clue_, or just a _Mud Clue_ for short.
-- The slot number corresponds to the ordering of the colors **from right to left**. But skip the cards that are not touched by the color clue (and the known unplayable cards). Furthermore, colors always "wrap around" to the oldest card.
+- The position of the muddy rainbow card, counted **from oldest to newest**, corresponds to the ordering of the colors **from right to left**. But skip the cards that are not touched by the color clue (and the known unplayable cards). Furthermore, colors always "wrap around" to the oldest card.
 - For example, in a 3-player game of the "Muddy Rainbow (6 Suits)" variant:
   - All of the 2's are played on the stacks.
   - Bob has two muddy rainbow cards clued in his hand on slot 3 and slot 4. He does not know the rank of either card.


### PR DESCRIPTION
The original formulation is misleading: it mentions the "slot number", whereas what is meant is the position of the card. This position is determined, from brown tempo clue conventions, from **right to left**. On the other hand, the original formulation leads to think it should be determined from **left to right**, as when counting slots.

Here is my attempt to resolve this possible misinterpretation.