### PR TITLE
Fix duplicitous-blind-play image

### DIFF
--- a/image-generator/yml/level-17/duplicitous-blind-play.yml
+++ b/image-generator/yml/level-17/duplicitous-blind-play.yml
@@ -39,5 +39,4 @@ players:
         clue: b
         below:
           - Blue 4
-          - Blue 5
       - type: x


### PR DESCRIPTION
Clued card is known not to be b5