### PR TITLE
Fix extra border in trash touch elim

### DIFF
--- a/image-generator/yml/level-18/trash-touch-elimination.yml
+++ b/image-generator/yml/level-18/trash-touch-elimination.yml
@@ -18,8 +18,11 @@ players:
       - type: r1
         clue: r
       - type: b1
+        border: false
       - type: g1
+        border: false
       - type: y1
+        border: false
   - cards:
       - type: x
         middle_note: r5?


### PR DESCRIPTION
Currently in https://hanabi.github.io/docs/level-18#trash-touch-elimination the b1/g1/y1 also have a border drawn on them, but in the context of the example I don't think that's correct.