### PR TITLE
Simplifies the process for determining the focus of a clue

### DIFF
--- a/docs/beginner/single-card-focus.mdx
+++ b/docs/beginner/single-card-focus.mdx
@@ -25,14 +25,13 @@ import ChopFocus from "@site/image-generator/yml/beginner/chop-focus.yml";
 
 <br />
 
-### Determining the Focus: 4 Steps
+### Determining the Focus: 2 Steps
 
 So, when two or more cards are touched by a clue, which card is focused?
 
-1. If no cards are new, then **the focus is on the left-most re-touched card**.
-1. If only one card is new, then **the focus is on the new card**.
-1. If two or more cards are new, and one of them was on chop, then **the focus is on the chop**.
-1. If two or more cards are new, and none of them were on chop, then **the focus is on the left-most new card**.
+1. If the card on chop is touched, then **the focus is on the chop**.
+1. Otherwise, **the focus is on the left-most new card**. 
+  - If no cards are new, then **the focus is on the left-most re-touched card**.
 
 <br />
 

--- a/docs/level-1.mdx
+++ b/docs/level-1.mdx
@@ -59,14 +59,13 @@ title: Level 1 - Fundamentals
 
 ### Clue Focus
 
-There is a 4-step process for determining the focus of a clue:
+There is a 2-step process for determining the focus of a clue:
 
-1. If no cards are new, then **the focus is on the left-most re-touched card**.
-1. If only one card is new, then **the focus is on the new card**.
-1. If two or more cards are new, and one of them was on chop, then **the focus is on the chop**.
-1. If two or more cards are new, and none of them were on chop, then **the focus is on the left-most new card**.
+1. If the card on chop is touched, then **the focus is on the chop**.
+1. Otherwise, **the focus is on the left-most new card**. 
+  - If no cards are new, then **the focus is on the left-most re-touched card**.
 
-This process is represented in the following flowchart:
+An alternative process is represented in the following flowchart:
 
 <img
   src="/img/flowcharts/clue-focus-flowchart.png"


### PR DESCRIPTION
We can replace the four-step process for determining the focus of a clue with a shorter yet logically equivalent two-step process:

> 
> 1. If the card on chop is touched, then **the focus is on the chop**.
> 1. Otherwise, **the focus is on the left-most new card**. 
>     - If no cards are new, then **the focus is on the left-most re-touched card**.