### PR TITLE
5CE and 4charm only work on new 4's/5's

### DIFF
--- a/docs/level-16.mdx
+++ b/docs/level-16.mdx
@@ -35,7 +35,7 @@ import UnknownTrashDischarge from "@site/image-generator/yml/level-16/unknown-tr
 
 ### The 5 Color Ejection (5CE)
 
-- Normally, if a player gives a color _Play Clue_ to a 5, it would mean that it is a _Finesse_ on the 5 and all of the cards leading up to the 5 are playable.
+- Normally, if a player gives a color _Play Clue_ to a previously untouched 5, it would mean that it is a _Finesse_ on the 5 and all of the cards leading up to the 5 are playable.
 - If the very next player sees that they will only have to **blind-play one card** in their hand to fulfill the _Finesse_, then they should assume that it is a _Finesse_ and blind-play their _Finesse Position_.
 - If the very next player sees that they would have to **blind-play two or more cards** in their hand to fulfill the _Finesse_, then a _Finesse_ is unlikely. Instead, players agree that this signals an _Ejection_ and that the next player should play their _Second Finesse Position_.
   - _Prompts_ don't factor into the "two or more blind-plays" rule. Players only count the number of blind-plays.

--- a/docs/level-24.mdx
+++ b/docs/level-24.mdx
@@ -26,7 +26,7 @@ import HesitationBlindPlay from "@site/image-generator/yml/level-24/hesitation-b
 
 ### The 4 Charm
 
-- When a _Play Clue_ is given to a 4 that is not yet playable, Bob must react:
+- When a _Play Clue_ is given to a previously untouched 4 that is not yet playable, Bob must react:
   - The first interpretation is that it is a _Prompt_.
   - If Bob has no matching cards in his hand, then a _Prompt_ is impossible.
   - The second interpretation is that it is a _Finesse_.


### PR DESCRIPTION
e.g. if a card was previously clued by 5 and then I fill it in with color, that does not trigger a 5CE

I _think_ this is how we play already. Correct me if I'm wrong. :P