### PR TITLE
Update level-9.mdx

### DIFF
--- a/docs/level-9.mdx
+++ b/docs/level-9.mdx
@@ -21,7 +21,7 @@ import FiveStall from "@site/image-generator/yml/level-9/five-stall.yml";
 | 4 (tied)   | _Locked Hand Save_<br />(saving any card on chop, as long as doing so would not _Lock_ the other player) | ❌                            | ❌                      | ❌                                           | ✅                       | ✅                   | use context           |
 | 4 (tied)   | _8 Clue Save_<br />(saving any card not on slot 1)                                                       | ❌                            | ❌                      | ❌                                           | ❌                       | ✅                   | use context           |
 | 4 (tied)   | _Fill-In Clue_<br />(giving extra information to already-clued cards or _Chop Moved_ cards)              | ❌                            | ❌                      | ✅                                           | ✅                       | ✅                   | use context           |
-| 5          | _Hard Burn_<br />(re-cluing an unplayable card that gives no new information, usually a 5)               | ❌                            | ❌                      | ✅                                           | ✅                       | ✅                   | use context           |
+| 5          | _Hard Burn_<br />(re-cluing a card that gives no new information, usually a 5)                           | ❌                            | ❌                      | ✅                                           | ✅                       | ✅                   | use context           |
 
 - For example:
   - It is the _Early Game_ (severity 1).


### PR DESCRIPTION
Currently you are not allowed to hard burn by giving no new information to a playable card. This seems very unintended as nobody plays like that and because that basically only applies to double ignitions / poke ejections etc.