### PR TITLE
For White, include number 5 clues as Always Loaded

### DIFF
--- a/docs/variant-specific/white.mdx
+++ b/docs/variant-specific/white.mdx
@@ -9,7 +9,7 @@ These conventions apply to any variant with a white suit (i.e. touched by no col
 
 ### The Loaded Play Clue Assumption
 
-- Since it can be hard to get white cards on chop to play, the _Always Loaded Principle_ applies to save clues given with number 2, number 3, and number 4.
+- Since it can be hard to get white cards on chop to play, the _Always Loaded Principle_ applies to save clues given with number 2, number 3, number 4, and number 5.
 - For example, in a 3-player game:
   - White 2 and red 2 are played on the stacks. Blue 3 is in the trash.
   - Bob has a globally-known playable green 1 in his hand.


### PR DESCRIPTION
We can state that the Always Loaded Principle applies to the White 5 as well. The Gray convention page states "normally, the Always Loaded Principle applies to white cards" and that the ALP doesn't apply to 2s and 5s, implying that the ALP does apply to 5s in White.