### PR TITLE
Clarifications in Level 16

### DIFF
--- a/docs/level-11.mdx
+++ b/docs/level-11.mdx
@@ -77,6 +77,8 @@ import BluffPromptsPromptBluffs from "@site/image-generator/yml/level-11/bluff-p
   - Since Bob does not see any red 3's, Bob knows he must have the red 3, and he blind-plays his _Finesse Position_ card. It is a blue 1 and successfully plays.
   - Bob now knows that he was _Bluffed_ by Alice and that the 4 in his hand is exactly the red 4.
 
+<br />
+
 ### Bluffs Through Already-Clued Cards
 
 - It is also permissible to _Bluff_ "through" cards that are already clued. This can be better than a normal _Bluff_, because in addition to getting the blind-play, it also can give information to the player with the in-between card.

--- a/docs/level-11.mdx
+++ b/docs/level-11.mdx
@@ -4,6 +4,7 @@ title: Level 11 - Bluffs
 ---
 
 import Bluff from "@site/image-generator/yml/level-11/bluff.yml";
+import SelfBluff from "@site/image-generator/yml/extras/special-bluffs/self-color-bluff.yml";
 import BluffThroughClued from "@site/image-generator/yml/level-11/bluff-through-already-clued-cards.yml";
 import TruthPrinciple from "@site/image-generator/yml/level-11/truth-principle.yml";
 import ColorConnect from "@site/image-generator/yml/level-11/color-connect.yml";
@@ -63,6 +64,21 @@ import BluffPromptsPromptBluffs from "@site/image-generator/yml/level-11/bluff-p
   - If a card is represented to be something different than what it really is, and the state of misinformation does not resolve immediately, it is called a _Lie_. _Lies_ are **illegal**. Players should **never** assume that they are _Lied_ to.
 
 <br />
+
+### The Self-Bluff
+
+- Just in the same way you can do a _Self-Finesse_, it is possible to perform a _Self-Bluff_ by cluing someone in order to get their own _Finesse Position_ card.
+- This is most generally done by giving a number clue on a _one-away-from-playable_ card which does not connect with the _Finesse Position_ card.
+- For _Self-Bluffs_ with color clues, see the [Self Color Bluffs](extras/special-bluffs.mdx#self-color-bluffs-1-for-1-form-scb) section.
+- For example, in a 3-player game:
+  - Red 2 is played on the stacks.
+  - Alice clues number 4 to Bob, which touches one new 4 as a _Play Clue_.
+  - Bob does not see any playable cards in anyone else's hand.
+  - The closest 4 to being playable is the red 4, so Bob knows that the 4 in his hand is probably a red 4.
+  - Since Bob does not see any red 3's, Bob knows he must have the red 3, and he blind-plays his _Finesse Position_ card. It is a blue 1 and successfully plays.
+  - Bob now knows that he was _Bluffed_ by Alice and that the 4 in his hand is exactly red 4.
+
+<SelfBluff />
 
 ### Bluffs Through Already-Clued Cards
 

--- a/docs/level-11.mdx
+++ b/docs/level-11.mdx
@@ -4,7 +4,6 @@ title: Level 11 - Bluffs
 ---
 
 import Bluff from "@site/image-generator/yml/level-11/bluff.yml";
-import SelfBluff from "@site/image-generator/yml/extras/special-bluffs/self-color-bluff.yml";
 import BluffThroughClued from "@site/image-generator/yml/level-11/bluff-through-already-clued-cards.yml";
 import TruthPrinciple from "@site/image-generator/yml/level-11/truth-principle.yml";
 import ColorConnect from "@site/image-generator/yml/level-11/color-connect.yml";
@@ -67,18 +66,16 @@ import BluffPromptsPromptBluffs from "@site/image-generator/yml/level-11/bluff-p
 
 ### The Self-Bluff
 
-- Just in the same way you can do a _Self-Finesse_, it is possible to perform a _Self-Bluff_ by cluing someone in order to get their own _Finesse Position_ card.
-- This is most generally done by giving a number clue on a _one-away-from-playable_ card which does not connect with the _Finesse Position_ card.
-- For _Self-Bluffs_ with color clues, see the [Self Color Bluffs](extras/special-bluffs.mdx#self-color-bluffs-1-for-1-form-scb) section.
+- In the same way you can do a _Self-Finesse_, it is possible to perform a _Self-Bluff_ by cluing someone in order to get their own _Finesse Position_ card.
+- Self-Bluffs must be given with rank clues, as a self-bluff with a color clue would be nonsensical.
+  - For players playing with extra conventions, see the section on the [Self Color Bluff](extras/special-bluffs.mdx#self-color-bluffs-1-for-1-form-scb).
 - For example, in a 3-player game:
   - Red 2 is played on the stacks.
   - Alice clues number 4 to Bob, which touches one new 4 as a _Play Clue_.
   - Bob does not see any playable cards in anyone else's hand.
   - The closest 4 to being playable is the red 4, so Bob knows that the 4 in his hand is probably a red 4.
   - Since Bob does not see any red 3's, Bob knows he must have the red 3, and he blind-plays his _Finesse Position_ card. It is a blue 1 and successfully plays.
-  - Bob now knows that he was _Bluffed_ by Alice and that the 4 in his hand is exactly red 4.
-
-<SelfBluff />
+  - Bob now knows that he was _Bluffed_ by Alice and that the 4 in his hand is exactly the red 4.
 
 ### Bluffs Through Already-Clued Cards
 

--- a/docs/level-16.mdx
+++ b/docs/level-16.mdx
@@ -129,7 +129,7 @@ import UnknownDupeDischarge2 from "@site/image-generator/yml/level-16/unknown-du
   1. When the team is at 8 clues (and there is nothing else to do).
   1. When a player is in a _Double Discard Situation_ (and there is nothing else to do).
   1. When the team is losing and nearing the _End-Game_ (and _Tempo_ on playable cards is really important).
-  1. When the efficiency of getting a _Layered Finesse_, a _Double Finesse_ or _Triple Finesse_ outweighs the disadvantage of potentially having to give a _Fix Clue_ later.
+  1. When the efficiency of getting a big _Finesse_ outweighs the disadvantage of potentially having to give a _Fix Clue_ later.
 - If a player uses a clue to duplicate a card, and these 5 criteria do not apply, then they must be trying to send an additional message.
 - In this case, they intend for a _Discharge_ to communicate the "badness" of the focused card. This is called an _Unknown Dupe Discharge_ (and works in a very similar way to the _Unknown Trash Discharge_).
 - After an _Unknown Dupe Discharge_, the focus of the clue can be any unknown duplicated card. The player will only know which specific duplicated card it is after they discard it.

--- a/docs/level-16.mdx
+++ b/docs/level-16.mdx
@@ -158,7 +158,7 @@ import UnknownDupeDischarge2 from "@site/image-generator/yml/level-16/unknown-du
   - Bob clues number 5 to Alice as a _5 Save_.
   - Bob's hand is as follows: `red 3, red 3, red 4, blue 4, blue [5]`
   - Cathy clues red to Bob, touching the red 3 on slot 1, the red 3 on slot 2, and the red 4 on slot 3.
-  - Alice knows that Cathy is violating _Good Touch Principle_ and duplicating the red 3. One excellent reason to do this would be to get a _Layered Finesse_ on red 1 + red 2 into the red 3.
+  - Alice knows that Cathy is violating _Good Touch Principle_ and duplicating the red 3. One excellent reason to do this would be to get a Double Finesse_ on red 1 + red 2 into the red 3.
   - However, Alice also knows that she is supposed to use the _two-or-more-blind-plays_ rule in this situation. Since Alice would have to blind-play two cards into the _Finesse_, a _Finesse_ is unlikely. Thus, this must be an _Unknown Dupe Discharge_.
   - Alice blind-plays her _Third Finesse Position_. It is a blue 1 and it successfully plays on the stacks.
 

--- a/docs/level-16.mdx
+++ b/docs/level-16.mdx
@@ -130,7 +130,7 @@ import UnknownDupeDischarge2 from "@site/image-generator/yml/level-16/unknown-du
   1. When a player is in a _Double Discard Situation_ (and there is nothing else to do).
   1. When the team is losing and nearing the _End-Game_ (and _Tempo_ on playable cards is really important).
   1. When the efficiency of getting a big _Finesse_ outweighs the disadvantage of potentially having to give a _Fix Clue_ later.
-- If a player uses a clue to duplicate a card, and these 5 criteria do not apply, then they must be trying to send an additional message.
+- If a player uses a clue to duplicate a card, and these criteria do not apply, then they must be trying to send an additional message.
 - In this case, they intend for a _Discharge_ to communicate the "badness" of the focused card. This is called an _Unknown Dupe Discharge_ (and works in a very similar way to the _Unknown Trash Discharge_).
 - After an _Unknown Dupe Discharge_, the focus of the clue can be any unknown duplicated card. The player will only know which specific duplicated card it is after they discard it.
 - For example, in a 3-player game:

--- a/docs/level-16.mdx
+++ b/docs/level-16.mdx
@@ -52,11 +52,12 @@ import UnknownDupeDischarge2 from "@site/image-generator/yml/level-16/unknown-du
 
 <FiveColorEjection />
 
-- In the previous example, a _5 Color Ejection_ was preformed with the 5 being the only new card introduced with the color clue. However, it is also possible to perform a _5 Color Ejection_ with more than one card introduced. Normally, this kind of thing would signal an _Out-of-Order Finesse_, but the _5 Color Ejection_ interpretation should take precedence as long as the next player would have to blind-play two or more cards.
+- In the previous example, a _5 Color Ejection_ was preformed with the 5 being the only new card introduced with the color clue. However, it is also possible to perform a _5 Color Ejection_ with more than one card introduced.
+- For players playing at level 21, this kind of thing would normally signal an _[Out-of-Order Finesse](the-out-of-order-finesse)_, but the _5 Color Ejection_ interpretation should take precedence as long as the next player would have to blind-play two or more cards.
 - For example, in a 3-player game:
   - It is the first turn and nothing is played on the stacks.
   - Alice clues red to Cathy, touching a red 5 on slot 2 and a red 2 on slot 3.
-  - Bob knows that normally, this would be an _Out-of-Order Finesse_ on the 5, indicating to Bob that he has the red 1, the red 3, and the red 4. However, since this calls for more than one blind card, he knows that _5 Color Ejection_ should take precedence, so he knows to play his _Second Finesse Position_ card. It is a red 1 and it successfully plays.
+  - Bob knows that at level 21, this would be an _Out-of-Order Finesse_ on the 5, indicating to Bob that he has the red 1, the red 3, and the red 4. However, since this calls for more than one blind card, he knows that _5 Color Ejection_ should take precedence, so he knows to play his _Second Finesse Position_ card. It is a red 1 and it successfully plays.
   - From Cathy's perspective, if Bob had played his _Finesse Position_ card in response to the red clue, then Cathy would know that it was a _Finesse_ or a _Bluff_. But since Bob blind-played his _Second Finesse Position_ card, it must be a _5 Color Ejection_. Cathy marks the red card as red 5. Her other red card can be red 2, red 3, or red 4.
 
 <FiveColorEjectionNotOOO />
@@ -128,8 +129,8 @@ import UnknownDupeDischarge2 from "@site/image-generator/yml/level-16/unknown-du
   1. When the team is at 8 clues (and there is nothing else to do).
   1. When a player is in a _Double Discard Situation_ (and there is nothing else to do).
   1. When the team is losing and nearing the _End-Game_ (and _Tempo_ on playable cards is really important).
-  1. When the efficiency of getting a _Double Finesse_ or _Triple Finesse_ outweighs the disadvantage of potentially having to give a _Fix Clue_ later.
-- If a player uses a clue to duplicate a card, and these 6 criteria do not apply, then they must be trying to send an additional message.
+  1. When the efficiency of getting a _Layered Finesse_, a _Double Finesse_ or _Triple Finesse_ outweighs the disadvantage of potentially having to give a _Fix Clue_ later.
+- If a player uses a clue to duplicate a card, and these 5 criteria do not apply, then they must be trying to send an additional message.
 - In this case, they intend for a _Discharge_ to communicate the "badness" of the focused card. This is called an _Unknown Dupe Discharge_ (and works in a very similar way to the _Unknown Trash Discharge_).
 - After an _Unknown Dupe Discharge_, the focus of the clue can be any unknown duplicated card. The player will only know which specific duplicated card it is after they discard it.
 - For example, in a 3-player game:
@@ -150,14 +151,14 @@ import UnknownDupeDischarge2 from "@site/image-generator/yml/level-16/unknown-du
   - It is explicitly illegal to perform an _Unknown Dupe Discharge_ that duplicates a card in someone else's hand. If this happens, the clue must have some other meaning.
 - Remember that after an _Unknown Dupe Discharge_, the player who received the clue is supposed to _discard the focus of the clue_.
   - However, in the case where only two new cards are touched, then the player who received the clue knows that both of these cards must be the same. In this special case, they can discard the non-focused card to cause a _Trash Order Chop Move_.
-- In order for players to determine whether or not a _Double Finesse_ or a _Triple Finesse_ is happening, they should use the same _two-or-more-blind-plays_ rule that applies to _5 Color Ejections_.
+- In order for players to determine whether or not a _Layered Finesse_, a _Double Finesse_ or a _Triple Finesse_ is happening, they should use the same _two-or-more-blind-plays_ rule that applies to _5 Color Ejections_.
 - For example, in a 3-player game (similar to the previous example):
   - It is the first turn of the game and nothing is played on the stacks.
   - Alice clues number 5 to Bob as a _5 Save_.
   - Bob clues number 5 to Alice as a _5 Save_.
   - Bob's hand is as follows: `red 3, red 3, red 4, blue 4, blue [5]`
   - Cathy clues red to Bob, touching the red 3 on slot 1, the red 3 on slot 2, and the red 4 on slot 3.
-  - Alice knows that Cathy is violating _Good Touch Principle_ and duplicating the red 3. One excellent reason to do this would be to get a _Double Finesse_ on red 1 + red 2 into the red 3.
+  - Alice knows that Cathy is violating _Good Touch Principle_ and duplicating the red 3. One excellent reason to do this would be to get a _Layered Finesse_ on red 1 + red 2 into the red 3.
   - However, Alice also knows that she is supposed to use the _two-or-more-blind-plays_ rule in this situation. Since Alice would have to blind-play two cards into the _Finesse_, a _Finesse_ is unlikely. Thus, this must be an _Unknown Dupe Discharge_.
   - Alice blind-plays her _Third Finesse Position_. It is a blue 1 and it successfully plays on the stacks.
 

--- a/docs/level-16.mdx
+++ b/docs/level-16.mdx
@@ -53,7 +53,7 @@ import UnknownDupeDischarge2 from "@site/image-generator/yml/level-16/unknown-du
 <FiveColorEjection />
 
 - In the previous example, a _5 Color Ejection_ was preformed with the 5 being the only new card introduced with the color clue. However, it is also possible to perform a _5 Color Ejection_ with more than one card introduced.
-- For players playing at level 21, this kind of thing would normally signal an _[Out-of-Order Finesse](the-out-of-order-finesse)_, but the _5 Color Ejection_ interpretation should take precedence as long as the next player would have to blind-play two or more cards.
+- For players playing at level 21, this kind of thing would normally signal an _[Out-of-Order Finesse](level-21.mdx#the-out-of-order-finesse)_, but the _5 Color Ejection_ interpretation should take precedence as long as the next player would have to blind-play two or more cards.
 - For example, in a 3-player game:
   - It is the first turn and nothing is played on the stacks.
   - Alice clues red to Cathy, touching a red 5 on slot 2 and a red 2 on slot 3.

--- a/docs/level-16.mdx
+++ b/docs/level-16.mdx
@@ -151,7 +151,7 @@ import UnknownDupeDischarge2 from "@site/image-generator/yml/level-16/unknown-du
   - It is explicitly illegal to perform an _Unknown Dupe Discharge_ that duplicates a card in someone else's hand. If this happens, the clue must have some other meaning.
 - Remember that after an _Unknown Dupe Discharge_, the player who received the clue is supposed to _discard the focus of the clue_.
   - However, in the case where only two new cards are touched, then the player who received the clue knows that both of these cards must be the same. In this special case, they can discard the non-focused card to cause a _Trash Order Chop Move_.
-- In order for players to determine whether or not a _Layered Finesse_, a _Double Finesse_ or a _Triple Finesse_ is happening, they should use the same _two-or-more-blind-plays_ rule that applies to _5 Color Ejections_.
+- In order for players to determine whether or not a _Finesse_ is happening, they should use the same _two-or-more-blind-plays_ rule that applies to _5 Color Ejections_.
 - For example, in a 3-player game (similar to the previous example):
   - It is the first turn of the game and nothing is played on the stacks.
   - Alice clues number 5 to Bob as a _5 Save_.

--- a/docs/level-16.mdx
+++ b/docs/level-16.mdx
@@ -158,7 +158,7 @@ import UnknownDupeDischarge2 from "@site/image-generator/yml/level-16/unknown-du
   - Bob clues number 5 to Alice as a _5 Save_.
   - Bob's hand is as follows: `red 3, red 3, red 4, blue 4, blue [5]`
   - Cathy clues red to Bob, touching the red 3 on slot 1, the red 3 on slot 2, and the red 4 on slot 3.
-  - Alice knows that Cathy is violating _Good Touch Principle_ and duplicating the red 3. One excellent reason to do this would be to get a Double Finesse_ on red 1 + red 2 into the red 3.
+  - Alice knows that Cathy is violating _Good Touch Principle_ and duplicating the red 3. One excellent reason to do this would be to get a _Double Finesse_ on red 1 + red 2 into the red 3.
   - However, Alice also knows that she is supposed to use the _two-or-more-blind-plays_ rule in this situation. Since Alice would have to blind-play two cards into the _Finesse_, a _Finesse_ is unlikely. Thus, this must be an _Unknown Dupe Discharge_.
   - Alice blind-plays her _Third Finesse Position_. It is a blue 1 and it successfully plays on the stacks.
 


### PR DESCRIPTION
List of changes:
- Proposal of clarifications on the example with an _Out-Of-Order Finesse_, since this only appears at level 21 and can be confusing for new players
- Changed a _6_ to a _5_ after the list of authorized duplications
- Added the mention of the _Layered-Finesse_ to the list of finesses allowing duplications. This is because the example originally said that Alice expected a _double-finesse_, however given that the clue is a color clue and there are only 3 players this would be nonsensical. I also modified that.