### PR TITLE
Double ignitions

### DIFF
--- a/docs/level-22.mdx
+++ b/docs/level-22.mdx
@@ -25,11 +25,9 @@ import ChopMoveIgnitionInteraction from "@site/image-generator/yml/level-22/chop
 
 - Several types of "useless" clues trigger a _Double Ignition_. These different types are listed below.
 - When a _Double Ignition_ is triggered, it means that two players on the team need to blind-play their _Finesse Position_ as any playable card.
-  - _Double Ignition_ does not necessarily have to be on the next two players. It can be on anyone.
-- In most circumstances, a _Double Ignition_ should be clear. This is because the two players that have a playable card will each see that the clue giver should have clued the other playable card directly (instead of giving a "useless" clue).
-- Sometimes, an _Ambiguous Double Ignition_ can happen (when three or more players have a playable card on _Finesse Position_). In this situation:
   - The first _Ignition_ **must always be on Bob**, unless Bob has a known-playable card already. Then, it would be on the first player that does not already have a known-playable card.
-  - The second _Ignition_ **must always be on the last player with a playable card**. (This is because the players in the middle will think that the last person is supposed to play, similar to how a normal _Ambiguous Finesse_ works.)
+- In most circumstances, a _Double Ignition_ should be clear. This is because the two players that have a playable card will each see that the clue giver should have clued the other playable card directly (instead of giving a "useless" clue).
+- Sometimes, an _Ambiguous Double Ignition_ can happen (when three or more players have a playable card on _Finesse Position_). In this situation, the second _Ignition_ **must always be on the last player with a playable card**. (This is because the players in the middle will think that the last person is supposed to play, similar to how a normal _Ambiguous Finesse_ works.)
 
 <br />
 

--- a/docs/level-22.mdx
+++ b/docs/level-22.mdx
@@ -25,9 +25,9 @@ import ChopMoveIgnitionInteraction from "@site/image-generator/yml/level-22/chop
 
 - Several types of "useless" clues trigger a _Double Ignition_. These different types are listed below.
 - When a _Double Ignition_ is triggered, it means that two players on the team need to blind-play their _Finesse Position_ as any playable card.
+- Similar to an _Ambiguous Finesse_, an _Ambiguous Double Ignition_ is possible. Specifically, this means that three or more players have a playable card on _Finesse Position_. In this situation, we strongly define who is supposed to be blind-playing:
   - The first _Ignition_ **must always be on Bob**, unless Bob has a known-playable card already. Then, it would be on the first player that does not already have a known-playable card.
-- In most circumstances, a _Double Ignition_ should be clear. This is because the two players that have a playable card will each see that the clue giver should have clued the other playable card directly (instead of giving a "useless" clue).
-- Sometimes, an _Ambiguous Double Ignition_ can happen (when three or more players have a playable card on _Finesse Position_). In this situation, the second _Ignition_ **must always be on the last player with a playable card**. (This is because the players in the middle will think that the last person is supposed to play, similar to how a normal _Ambiguous Finesse_ works.)
+  - The second _Ignition_ **must always be on the last player with a playable card**.
 
 <br />
 


### PR DESCRIPTION
The current wording of double ignitions suggests that Alice can perform a DI that gets Cathy's and Donald's finesse positions even when Bob has nothing to play. 