### PR TITLE
Update critical-fours.mdx

### DIFF
--- a/docs/variant-specific/critical-fours.mdx
+++ b/docs/variant-specific/critical-fours.mdx
@@ -11,12 +11,4 @@ These conventions apply to any variant with critical fours.
 
 ### Special Suit Cases
 
-In a combination of critical fours and a special suit, the four of that special suit is saved according to the conventions governing that special suit. Specifically:
-
-- **Black**: Black 4 is saved with black.
-- **Brown**: Brown 4 is saved with brown.
-- **Dark Pink**: Dark pink 4 is saved with pink.
-- **Dark Omni**: Dark omni 4 is saved with a 5 number clue.
-- **Gray Pink**: Gray pink 4 is saved with a 5 number clue.
-- **Muddy Rainbow**: Muddy rainbow 4 is saved with red.
-- **Cocoa Rainbow**: Cocoa rainbow 4 is saved with red.
+- In variants with a special suit, the four of that special suit is instead saved according to the conventions governing that special suit.


### PR DESCRIPTION
This PR removes most of the special suits section from my previous PR #1174 because conventions for save clues in special suits change over time and the summaries were simplistic (e.g. with black) anyway.