### PR TITLE
Update level 13 (crit color bluffs)

### DIFF
--- a/docs/level-13.mdx
+++ b/docs/level-13.mdx
@@ -89,7 +89,7 @@ import HardBluff from "@site/image-generator/yml/level-13/hard-bluff.yml";
 - Building on the _3 Bluffs_ convention, we also agree that it is possible for a card that initiates a _Bluff_ to be any critical card, but only if **a color clue** is used, and only if **it is not a 5**.
 - You can initiate a _Critical Color Bluff_ with either a completely-unclued critical card or an already-clued critical card; the same connect/disconnect rules apply in both cases.
 - For example, in a 3-player game:
-  - Nothing is played on the stacks. 
+  - Nothing is played on the stacks.
   - Alice clues Cathy black, touching a black 4 as a _Play Clue_.
   - Bob blind-plays a blue 1.
   - Cathy marks her red card as the _one-away-from-playable_ black card, the black 2.

--- a/docs/level-13.mdx
+++ b/docs/level-13.mdx
@@ -87,7 +87,7 @@ import HardBluff from "@site/image-generator/yml/level-13/hard-bluff.yml";
 ### The Critical Color Bluff
 
 - Building on the _3 Bluffs_ convention, we also agree that it is possible for a card that initiates a _Bluff_ to be any critical card, but only if **a color clue** is used, and only if **it is not a 5**.
-- This includes black 4 or any dark 4.
+  - Note that this includes the special black 4 (or any "dark" 4).
 - You can initiate a _Critical Color Bluff_ with either a completely-unclued critical card or an already-clued critical card; the same connect/disconnect rules apply in both cases.
 - For example, in a 3-player game:
   - Nothing is played on the stacks. Red 4 is currently in the discard pile.

--- a/docs/level-13.mdx
+++ b/docs/level-13.mdx
@@ -87,15 +87,15 @@ import HardBluff from "@site/image-generator/yml/level-13/hard-bluff.yml";
 ### The Critical Color Bluff
 
 - Building on the _3 Bluffs_ convention, we also agree that it is possible for a card that initiates a _Bluff_ to be any critical card, but only if **a color clue** is used, and only if **it is not a 5**.
-- _Critical Color Bluff_ can also be initiated with Black 4 or any dark 4.
+- This includes black 4 or any dark 4.
 - You can initiate a _Critical Color Bluff_ with either a completely-unclued critical card or an already-clued critical card; the same connect/disconnect rules apply in both cases.
 - For example, in a 3-player game:
-  - Nothing is played on the stacks. Red 4 is in the trash.
-  - Alice clues Cathy black, touching a red 4 as a _Play Clue_.
+  - Nothing is played on the stacks. Red 4 is currently in the discard pile.
+  - Alice clues Cathy red, touching a red 4 as a _Play Clue_.
   - Bob blind-plays a blue 1.
   - Cathy marks her red card as the _one-away-from-playable_ red card, the red 2.
   - However, Cathy also knows that _3 Bluffs_ are a thing, so she _also_ marks her red card as possibly a red 3.
-  - However, Cathy also knows that _Critical Color Bluffs_ are a thing, so she _also_ marks her black card as possibly a red 4.
+  - However, Cathy also knows that _Critical Color Bluffs_ are a thing, so she _also_ marks her red card as possibly a red 4.
 
 <CriticalColorBluff />
 

--- a/docs/level-13.mdx
+++ b/docs/level-13.mdx
@@ -90,12 +90,12 @@ import HardBluff from "@site/image-generator/yml/level-13/hard-bluff.yml";
 - _Critical Color Bluff_ can also be initiated with Black 4 or any dark 4.
 - You can initiate a _Critical Color Bluff_ with either a completely-unclued critical card or an already-clued critical card; the same connect/disconnect rules apply in both cases.
 - For example, in a 3-player game:
-  - Nothing is played on the stacks.
-  - Alice clues Cathy black, touching a black 4 as a _Play Clue_.
+  - Nothing is played on the stacks. Red 4 is in the trash.
+  - Alice clues Cathy black, touching a red 4 as a _Play Clue_.
   - Bob blind-plays a blue 1.
-  - Cathy marks her red card as the _one-away-from-playable_ black card, the black 2.
-  - However, Cathy also knows that _3 Bluffs_ are a thing, so she _also_ marks her black card as possibly a black 3.
-  - However, Cathy also knows that _Critical Color Bluffs_ are a thing, so she _also_ marks her black card as possibly a black 4.
+  - Cathy marks her red card as the _one-away-from-playable_ red card, the red 2.
+  - However, Cathy also knows that _3 Bluffs_ are a thing, so she _also_ marks her red card as possibly a red 3.
+  - However, Cathy also knows that _Critical Color Bluffs_ are a thing, so she _also_ marks her black card as possibly a red 4.
 
 <CriticalColorBluff />
 

--- a/docs/level-13.mdx
+++ b/docs/level-13.mdx
@@ -89,12 +89,12 @@ import HardBluff from "@site/image-generator/yml/level-13/hard-bluff.yml";
 - Building on the _3 Bluffs_ convention, we also agree that it is possible for a card that initiates a _Bluff_ to be any critical card, but only if **a color clue** is used, and only if **it is not a 5**.
 - You can initiate a _Critical Color Bluff_ with either a completely-unclued critical card or an already-clued critical card; the same connect/disconnect rules apply in both cases.
 - For example, in a 3-player game:
-  - Nothing is played on the stacks. Red 4 is currently in the discard pile.
-  - Alice clues Cathy red, touching a red 4 as a _Play Clue_.
+  - Nothing is played on the stacks. 
+  - Alice clues Cathy black, touching a black 4 as a _Play Clue_.
   - Bob blind-plays a blue 1.
-  - Cathy marks her red card as the _one-away-from-playable_ red card, the red 2.
-  - However, Cathy also knows that _3 Bluffs_ are a thing, so she _also_ marks her red card as possibly a red 3.
-  - However, Cathy also knows that _Critical Color Bluffs_ are a thing, so she _also_ marks her red card as possibly a red 4.
+  - Cathy marks her red card as the _one-away-from-playable_ black card, the black 2.
+  - However, Cathy also knows that _3 Bluffs_ are a thing, so she _also_ marks her black card as possibly a black 3.
+  - However, Cathy also knows that _Critical Color Bluffs_ are a thing, so she _also_ marks her black card as possibly a black 4.
 
 <CriticalColorBluff />
 

--- a/docs/level-13.mdx
+++ b/docs/level-13.mdx
@@ -87,6 +87,7 @@ import HardBluff from "@site/image-generator/yml/level-13/hard-bluff.yml";
 ### The Critical Color Bluff
 
 - Building on the _3 Bluffs_ convention, we also agree that it is possible for a card that initiates a _Bluff_ to be any critical card, but only if **a color clue** is used, and only if **it is not a 5**.
+- _Critical Color Bluff_ can also be initiated with Black 4 or any dark 4.
 - You can initiate a _Critical Color Bluff_ with either a completely-unclued critical card or an already-clued critical card; the same connect/disconnect rules apply in both cases.
 - For example, in a 3-player game:
   - Nothing is played on the stacks.

--- a/image-generator/yml/level-13/critical-color-bluff.yml
+++ b/image-generator/yml/level-13/critical-color-bluff.yml
@@ -1,13 +1,13 @@
-suits:
-  k: black
 stacks:
   - r: 0
   - y: 0
   - g: 0
   - b: 0
-  - k: 0
+  - p: 0
 big_text:
   text: Bluff
+discarded:
+  - r4
 players:
   - clue_giver: true
     cards:
@@ -25,9 +25,9 @@ players:
       - type: x
   - cards:
       - type: x
-      - type: k
-        clue: black
-        above: Black 4
+      - type: r
+        clue: r
+        middle_note: (4)
       - type: x
       - type: x
       - type: x
@@ -35,13 +35,13 @@ players:
   - name: Cathy
     cards:
       - type: x
-      - type: k
+      - type: r
         below:
           text:
-            - Black 2
-            - Black 3
-            - Black 4
-          color: black
+            - Red 2
+            - Red 3
+            - Red 4
+          color: red
       - type: x
       - type: x
       - type: x

--- a/image-generator/yml/level-13/critical-color-bluff.yml
+++ b/image-generator/yml/level-13/critical-color-bluff.yml
@@ -1,13 +1,13 @@
+suits:
+  k: black
 stacks:
   - r: 0
   - y: 0
   - g: 0
   - b: 0
-  - p: 0
+  - k: 0
 big_text:
   text: Bluff
-discarded:
-  - r4
 players:
   - clue_giver: true
     cards:
@@ -25,9 +25,9 @@ players:
       - type: x
   - cards:
       - type: x
-      - type: r
-        clue: r
-        middle_note: (4)
+      - type: k
+        clue: black
+        above: Black 4
       - type: x
       - type: x
       - type: x
@@ -35,13 +35,13 @@ players:
   - name: Cathy
     cards:
       - type: x
-      - type: r
+      - type: k
         below:
           text:
-            - Red 2
-            - Red 3
-            - Red 4
-          color: red
+            - Black 2
+            - Black 3
+            - Black 4
+          color: black
       - type: x
       - type: x
       - type: x


### PR DESCRIPTION
Since critical color bluffs originated from the black 4 bluff, it's always been H-group history that critical color bluffs can also apply to dark 4s. However, it seems like many newer players do not realize this, since the docs don't state this explicitly.

By changing the example from a bluff on red 4 to black 4, we can make this clearer without changing any wording.