### PR TITLE
Fixing text to match picture

### DIFF
--- a/docs/extras/charms.mdx
+++ b/docs/extras/charms.mdx
@@ -50,7 +50,7 @@ import UnknownTrashCharm from "@site/image-generator/yml/extras/charms/unknown-t
 - The _Out-of-Order Finesse_ always takes precedence over a _4 Charm_ or a _4's Double Bluff_, because of _Bob's Truth Principle_.
 - For example, in a 4-player game:
   - It is the first turn and nothing is played on the stacks.
-  - Donald's hand is as follows, from left to right: `red 4, red 1, blue 3, blue 3`
+  - Donald's hand is as follows, from left to right: `blue 3, red 4, red 1, blue 3`
   - Alice clues red to Donald, touching the red 4 on slot 1 and the red 1 on slot 2. This is a _Play Clue_.
   - Bob knows that this could be the truth as an _Out-of-Order Finesse_. If that is the case, he should clue number 4 to Donald, allowing him to play the red 1. Then, Bob can blind-play the red 2 and the red 3 (into the playable red 4).
   - Bob knows that this could also be a _4 Charm_, since the red 4 is _three-away-from-playable_ and Bob does not see any other red cards on _Finesse Position_.


### PR DESCRIPTION
<img width="1015" alt="Screenshot 2024-04-19 at 4 36 20 PM" src="https://github.com/hanabi/hanabi.github.io/assets/23708911/b1f06551-f6c4-425e-8789-ad11f1624217">

Fixing the text in the description to match the image right below it.

It does not substantively change the example as the focus is still the same, but it is inconsistent with what is directly below it.

Alternatively, could change the image, but this seemed easier.