### PR TITLE
Update level-14.mdx

### DIFF
--- a/docs/level-14.mdx
+++ b/docs/level-14.mdx
@@ -87,7 +87,7 @@ import TrashPush from "@site/image-generator/yml/level-14/trash-push.yml";
 
 <TrashFinesseTwoCards />
 
-- For level 25 players, there are [additional rules](level-25.mdx#trash-finesses-and-trash-bluffs-are-always-unnecessary) relating to \_Trash Finesses.
+- For level 25 players, there are [additional rules](level-25.mdx#trash-finesses-and-trash-bluffs-are-always-unnecessary) relating to _Trash Finesses_.
 
 ### The Reverse Trash Finesse
 

--- a/image-generator/yml/level-14/trash-bluff.yml
+++ b/image-generator/yml/level-14/trash-bluff.yml
@@ -34,5 +34,17 @@ players:
       - type: 1
         trash: true
       - type: x
+        above:
+          text:
+            - Chop
+            - Moved
       - type: x
+        above:
+          text:
+            - Chop
+            - Moved
       - type: x
+        above:
+          text:
+            - Chop
+            - Moved

--- a/image-generator/yml/level-14/trash-finesse-two-cards.yml
+++ b/image-generator/yml/level-14/trash-finesse-two-cards.yml
@@ -39,4 +39,12 @@ players:
       - type: 1
         trash: true
       - type: x
+        above:
+          text:
+            - Chop
+            - Moved
       - type: x
+        above:
+          text:
+            - Chop
+            - Moved

--- a/image-generator/yml/level-14/trash-finesse.yml
+++ b/image-generator/yml/level-14/trash-finesse.yml
@@ -36,4 +36,12 @@ players:
       - type: 1
         trash: true
       - type: x
+        above:
+            text:
+              - Chop
+              - Moved
       - type: x
+        above:
+            text:
+              - Chop
+              - Moved

--- a/image-generator/yml/level-14/trash-finesse.yml
+++ b/image-generator/yml/level-14/trash-finesse.yml
@@ -37,11 +37,11 @@ players:
         trash: true
       - type: x
         above:
-            text:
-              - Chop
-              - Moved
+          text:
+            - Chop
+            - Moved
       - type: x
         above:
-            text:
-              - Chop
-              - Moved
+          text:
+            - Chop
+            - Moved


### PR DESCRIPTION
- Fixes a minor formatting issue on one of the italicized texts
- Adds the "Chop Moved" indicator in the example cards for trash finesse and trash bluff