### PR TITLE
Reorganize Reversed conventions by level

### DIFF
--- a/docs/variant-specific/reversed.mdx
+++ b/docs/variant-specific/reversed.mdx
@@ -5,33 +5,13 @@ title: Reversed
 
 These conventions apply to any variant with a reversed suit (cards must be played as 5 --> 4 --> 3 --> 2 --> 1).
 
+## Basic reversed principles
+
 ### The 1 Save
 
 - Similar to the _5 Save_, you can also do a _1 Save_ in order to save the reversed 1. (There is only one copy of a reversed 1.)
 - Any number 1 clue to a chop card is first and foremost respected as a _1 Save_ (as opposed to a _Play Clue_ on a playable 1).
 - If a _1 Save_ touches more than one 1, the non-chop 1s can be played as per normal.
-
-### The Fix Clue That Re-Touches 1's
-
-- Normally, when 1's are re-clued with number 1 before they are all played, it means to skip over the next one because it is trash.
-- In a variant with a reversed suit, it means instead that the card is the reversed 1.
-- For example:
-  - Alice clues Bob number 1 and it touches three 1's.
-  - Bob plays the oldest 1. There are now two 1's left in his hand.
-  - Before Bob can play the next 1, Alice clues Bob number 1 again, and all the clue does is re-touch the remaining 1's.
-  - Now it is Bob's turn. Since he was going to play the 1 already without Alice doing anything, the clue must have some other meaning.
-  - Thus, it must be a _Fix Clue_. Just like in a no variant game, Bob skips over the 1 that he was about to play and plays the other one. It successfully plays.
-  - In a no variant game, Bob would know that the 1 that he skipped over would be trash and he could safely discard it on his next turn. However, since this is a reversed variant, Bob instead assumes that the skipped over 1 is exactly the reversed 1. He saves the card for later.
-
-### No Play Clues with a Number 5 Clue
-
-- In a no variant game, all number 5 clues in the _Low Score Phase_ are never to be interpreted as a _Play Clue_. If players want to get some 5 to play, they must clue it with color.
-- This convention also applies to variants with a reversed suit. If players want to get a reversed 5 to play, they must clue it with color.
-- This means that _5 Stalls_, _5's Chop Moves_, and _5 Pulls_ will still "work" like they normally do, even in a variant with a reversed suit.
-- The exception to this rule is when playing a variant with a white reversed suit:
-  - In this case, as long as the reversed white 5 is not yet played, all _5 Stalls_, _5's Chop Moves_, and _5 Pulls_ are "turned off".
-  - Instead, any number 5 clue will just look like a simple _Play Clue_ on a reversed white 5.
-  - Once the reversed white 5 is played, these three conventions are turned back on.
 
 ### No 2 Saves on a Reversed 2
 
@@ -50,23 +30,17 @@ These conventions apply to any variant with a reversed suit (cards must be playe
 - Players are not allowed to _Order Chop Move_, because they could be misplaying a reversed card.
   - The exception is when the reversed 1 is visible.
 
-### The 2 Double Bluff
+### The Fix Clue That Re-Touches 1's
 
-- Similar to the _4 Double Bluff_, you can also use a reversed 2 to initiate a _2 Double Bluff_ in exactly the same way.
-
-### The 1 Double Bluff
-
-- Similar to the _5 Double Bluff_, you can also use a reversed 1 to initiate a _1 Double Bluff_ in exactly the same way.
-
-### 1 Color Ejection (1CE)
-
-- Similar to _5 Color Ejection_, it is also possible to perform a _1 Color Ejection_ on a reversed suit.
-- _1 Color Ejection_ works in the exact same way that _5 Color Ejection_ does (e.g. players use the "two-or-more blind-plays" rule).
-
-### 2 Charm
-
-- Similar to _4 Charm_, it is also possible to perform a _2 Charm_ in an _Up or Down_ variant.
-- _2 Charms_ works in the exact same way that _4 Charms do_ (e.g. players use the "three-or-more blind-plays" rule).
+- Normally, when 1's are re-clued with number 1 before they are all played, it means to skip over the next one because it is trash.
+- In a variant with a reversed suit, it means instead that the card is the reversed 1.
+- For example:
+  - Alice clues Bob number 1 and it touches three 1's.
+  - Bob plays the oldest 1. There are now two 1's left in his hand.
+  - Before Bob can play the next 1, Alice clues Bob number 1 again, and all the clue does is re-touch the remaining 1's.
+  - Now it is Bob's turn. Since he was going to play the 1 already without Alice doing anything, the clue must have some other meaning.
+  - Thus, it must be a _Fix Clue_. Just like in a no variant game, Bob skips over the 1 that he was about to play and plays the other one. It successfully plays.
+  - In a no variant game, Bob would know that the 1 that he skipped over would be trash and he could safely discard it on his next turn. However, since this is a reversed variant, Bob instead assumes that the skipped over 1 is exactly the reversed 1. He saves the card for later.
 
 ### 1's Chop Move
 
@@ -76,6 +50,23 @@ These conventions apply to any variant with a reversed suit (cards must be playe
   - If they happen to see the real copy of the reversed 1 at a later point in the game, then they can discard the 1 as known-trash.
 - If there are two or more cards are touched from _1's Chop Move_, the reversed 1 is promised on the right-most.
 
+## Level 15 - Double Bluffs
+
+### The 2 Double Bluff
+
+- Similar to the _4 Double Bluff_, you can also use a reversed 2 to initiate a _2 Double Bluff_ in exactly the same way.
+
+### The 1 Double Bluff
+
+- Similar to the _5 Double Bluff_, you can also use a reversed 1 to initiate a _1 Double Bluff_ in exactly the same way.
+
+## Level 16 - Ejections
+
+### 1 Color Ejection (1CE)
+
+- Similar to _5 Color Ejection_, it is also possible to perform a _1 Color Ejection_ on a reversed suit.
+- _1 Color Ejection_ works in the exact same way that _5 Color Ejection_ does (e.g. players use the "two-or-more blind-plays" rule).
+
 ### The Turnabout Ejection (for 1s)
 
 - [Turnabout Ejections](pink.mdx#the-turnabout-ejection) can be performed on a reversed 1 in the same way that they can on a pink 5.
@@ -83,3 +74,22 @@ These conventions apply to any variant with a reversed suit (cards must be playe
   - if a reversed 1 is the focus of a number 1 clue that is a _Play Clue_,
   - and the next player would need to blind-play two or more cards to fulfill a _Finesse_,
   - then they would instead interpret the clue as a _Turnabout Ejection_ (similar to 1CE).
+
+## Level 19 - 5 Tech
+
+### No Play Clues with a Number 5 Clue
+
+- In a no variant game, all number 5 clues in the _Low Score Phase_ are never to be interpreted as a _Play Clue_. If players want to get some 5 to play, they must clue it with color.
+- This convention also applies to variants with a reversed suit. If players want to get a reversed 5 to play, they must clue it with color.
+- This means that _5 Stalls_, _5's Chop Moves_, and _5 Pulls_ will still "work" like they normally do, even in a variant with a reversed suit.
+- The exception to this rule is when playing a variant with a white reversed suit:
+  - In this case, as long as the reversed white 5 is not yet played, all _5 Stalls_, _5's Chop Moves_, and _5 Pulls_ are "turned off".
+  - Instead, any number 5 clue will just look like a simple _Play Clue_ on a reversed white 5.
+  - Once the reversed white 5 is played, these three conventions are turned back on.
+
+## Level 24 - Charms
+
+### 2 Charm
+
+- Similar to _4 Charm_, it is also possible to perform a _2 Charm_ in an _Up or Down_ variant.
+- _2 Charms_ works in the exact same way that _4 Charms do_ (e.g. players use the "three-or-more blind-plays" rule).


### PR DESCRIPTION
In the reversed conventions, I noticed that "No Order Chop Moves" was listed after "The 1's Fix Clue", which doesn't make any sense. 

So I decided to try to organize the conventions by level, just like the Pink conventions.

(In Pink, the "Turnabout Ejection" is listed as Level 21, but here I decided to group it with the "1 Color Ejection" at level 16. I am open for discussion around this..)