### PR TITLE
Patch 4

### DIFF
--- a/docs/level-19.mdx
+++ b/docs/level-19.mdx
@@ -97,7 +97,7 @@ import InteractionsBetween2SavesAnd5Stalls from "@site/image-generator/yml/level
 - The "pulled" card will always connect to the final blind-play.
 - For example in a 4-player game:
   - It is the first turn of the game and nothing is played on the stacks.
-  - Donald's hand is as follows, from newest to oldest: `blue 4, blue 5, red 3, blue 2`
+  - Donald's hand is as follows, from newest to oldest: `blue 4, blue 5, red 3, yellow 1`
   - Alice clues number 5 to Donald, touching the blue 5 on slot 2.
   - Bob blind-plays the red 1 (because he knows that it cannot be a _5 Stall_).
   - Cathy blind-plays the red 2 (because she knows that she needs to play into the _Double Finesse_).

--- a/image-generator/yml/level-19/the-five-pull-double-finesse.yml
+++ b/image-generator/yml/level-19/the-five-pull-double-finesse.yml
@@ -33,5 +33,5 @@ players:
         clue: 5
       - type: r3
         border: false
-      - type: b2
+      - type: y1
         border: false


### PR DESCRIPTION
Bob sees that Alice didn't clue Donald's b2, but he doesn't know whether his hand contains the other b2. So, he cannot know for sure that this is a 5 Pull Double Finesse. Instead, he looks to the Visible Rule and will assume that this is just a 5 Stall. To make this more clear in the documentation, I suggest changing Donald's b2 to a clearly gettable card like y1.