### PR TITLE
Link loaded definitions in convention reference document (for #1237)

### DIFF
--- a/docs/variant-specific.mdx
+++ b/docs/variant-specific.mdx
@@ -93,7 +93,7 @@ import LoadedException2 from "@site/image-generator/yml/extras/variant-specific/
 - For example:
   - In a dark prism variant, a 3 or 4 clue to the chop always looks like a _Save Clue_ on prism 3 or prism 4.
   - In a brown variant, a brown clue to the chop always looks like a _Save Clue_ on a brown 2, a brown 5, or another critical brown card.
-- In such cases, we agree that this specific type of clue, if given to a player who is _Loaded_, must always be treated as a play clue. (This includes during the _Early Game_ and in _Double Discard Situations_.)
+- In such cases, we agree that this specific type of clue, if given to a player who is [Loaded](#the-early-save), must always be treated as a play clue. (This includes during the _Early Game_ and in _Double Discard Situations_.)
 - For example, in a 3-player game with a gray suit:
   - Gray 1 and blue 1 are played on the stacks.
   - Bob's hand is completely unclued.

--- a/docs/variant-specific/brown.mdx
+++ b/docs/variant-specific/brown.mdx
@@ -26,7 +26,7 @@ These conventions apply to any variant with a brown (touched by no ranks) suit.
 
 ### The Brown Loaded Play Clue
 
-- _Loaded Play Clues_ are always "turned on" for brown cards, according to the _Always Loaded Principle_.
+- [Loaded Play Clues](../variant-specific.mdx#the-loaded-play-clue-in-hard-variants-lpc) are always "turned on" for brown cards, according to the [Always Loaded Principle](../variant-specific.mdx#the-always-loaded-principle-alp).
 
 ### Positional Clues
 

--- a/docs/variant-specific/duck.mdx
+++ b/docs/variant-specific/duck.mdx
@@ -21,7 +21,7 @@ These conventions apply to the "Duck" variants.
 
 ### Loaded Play Clues
 
-- _Loaded Play Clues_ are "turned on" in Duck variants. Furthermore, _Loaded Play Clues_ are even turned on in the _Early Game_.
+- [Loaded Play Clues](../variant-specific.mdx#the-loaded-play-clue-in-hard-variants-lpc) are "turned on" in Duck variants. Furthermore, _Loaded Play Clues_ are even turned on in the _Early Game_.
 
 ### The Loaded Finesse
 

--- a/docs/variant-specific/white.mdx
+++ b/docs/variant-specific/white.mdx
@@ -7,7 +7,7 @@ These conventions apply to any variant with a white suit (i.e. touched by no col
 
 ### The Loaded Play Clue Assumption
 
-- Since it can be hard to get white cards on chop to play, the _Always Loaded Principle_ applies to save clues given with number 3 and number 4.
+- Since it can be hard to get white cards on chop to play, the [Always Loaded Principle](../variant-specific.mdx#the-always-loaded-principle-alp) applies to save clues given with number 3 and number 4.
   - The _Always Loaded Principle_ never applies to number 2 clues or number 5 clues.
 - For example, in a 3-player game:
   - White 2 and red 2 are played on the stacks. Blue 3 is in the trash.


### PR DESCRIPTION
added links to definitions for "Loaded Play Clue", "Always Loaded Principle" and "Loaded"