### PR TITLE
realign trash moves in pink 

### DIFF
--- a/docs/variant-specific/omni.mdx
+++ b/docs/variant-specific/omni.mdx
@@ -23,13 +23,6 @@ These conventions apply to any variant with an omni (touched by all clues) suit.
   - Alice gives a _Play Clue_ to an omni 3 in Cathy's hand.
   - Bob knows that he is _Prompted_ for the omni 2. He plays the number 1 card (as opposed to blind-playing slot 1 as a _Finesse_).
 
-### Trash Pushes in Omni
-
-- When a _Trash Push_ happens in a normal variant, if more than one card is touched, then all of the touched cards are known to be trash.
-- When a _Trash Push_ happens in a variant with an omni suit, if more than one card is touched, it is possible that only the card on chop was trash, and that the other cards touched are useful / critical omni cards.
-- In this situation, after blind-playing the _Trash Pushed_ card, the player should first discard the card that initiated the _Trash Push_ (the oldest card) and then hold on to the other touched cards.
-  - In this situation, _Good Touch Principle_ applies to the other touched cards. The other members of the team must give a _Fix Clue_ to those cards if they are also trash.
-
 ### Mud Clues
 
 - [_Mud Clues_](muddy-rainbow-cocoa-rainbow.mdx#mud-clues) (from muddy rainbow variants) also apply to omni cards.

--- a/docs/variant-specific/pink.mdx
+++ b/docs/variant-specific/pink.mdx
@@ -368,12 +368,9 @@ These conventions apply to any variant with a pink (touched by all ranks) suit.
 
 ## Level 21 - Edge Cases
 
-### Trash Pushes in Pink
+### Trash Moves in Pink
 
-- When a _Trash Push_ happens in a normal variant, if more than one card is touched, then all of the touched cards are known to be trash.
-- When a _Trash Push_ happens with a rank clue in a variant with a pink suit, if more than one card is touched, it is possible that only the card on chop was trash, and that the other cards touched are useful / critical pink cards.
-- In this situation, after blind-playing the _Trash Pushed_ card, the player should first discard the card that initiated the _Trash Push_ (the oldest card) and then hold on to the other touched cards.
-  - In this situation, _Good Touch Principle_ applies to the other touched cards. The other members of the team must give a _Fix Clue_ to those cards if they are also trash.
+- When a _Trash Chop Move_, _Trash Bluff_, _Trash Finesse_, or _Trash Push_ happens with a rank clue in a variant with a pink suit, if more than one card is touched, then all of the touched cards are known to be trash.
 
 ### Pink Precedence
 
@@ -426,18 +423,6 @@ These conventions apply to any variant with a pink (touched by all ranks) suit.
   - Later on in the game, another rank clue "fills in" Bob's slot 4 card to be a pink card. From _Pink Promise_, Bob knows that it must be exactly the pink 5.
 
 <Promise5ChopMove />
-
-### Pink Promise with a Trash Chop Move
-
-- First, see the section on _[Pink Promise with a 5's Chop Move](#pink-promise-with-a-5s-chop-move)_.
-- In a _5's Chop Move_:
-  - The focus of the clue is the 5 that is one-away from chop.
-  - _Pink Promise_ applies to the focused 5.
-  - Other cards, if any, are not necessarily promised to be anything.
-- This same convention applies to a _Trash Chop Move_ given with a number clue. In a _Trash Chop Move_ given with a number clue:
-  - The focus of the clue is the touched card that is closest to chop.
-  - The focus of the clue is promised to be trash.
-  - Other cards, if any, are not necessarily promised to be anything.
 
 ### Pink Promise with a 5 Pull
 

--- a/docs/variant-specific/pink.mdx
+++ b/docs/variant-specific/pink.mdx
@@ -371,6 +371,7 @@ These conventions apply to any variant with a pink (touched by all ranks) suit.
 ### Trash Moves in Pink
 
 - When a _Trash Chop Move_, _Trash Bluff_, _Trash Finesse_, or _Trash Push_ happens with a rank clue in a variant with a pink suit, if more than one card is touched, then all of the touched cards are known to be trash.
+- This is the exactly how it works in any other variant, but we repeat it here because it is theoretically possible for the clue receiver to think that the non-focused cards are useful pink cards. However, by convention, we treat all of the cards as trash.
 
 ### Pink Precedence
 


### PR DESCRIPTION
convention proposal: https://discord.com/channels/140016142600241152/1289284121260068937/1289284121260068937

- Now all cards touched in trash cm and trash push are trash. This realigns these trash moves with trash bluff/finesse in pink.
- omni now inherits the trash moves conventions from pink (removed trash push section)