### PR TITLE
fix: clarify 5s Chop Move

### DIFF
--- a/docs/level-4.mdx
+++ b/docs/level-4.mdx
@@ -72,7 +72,7 @@ import ChopMovePrompt from "./level-4/chop-move-prompt.yml";
 - Normally, **we are only allowed to save 5's that are on chop**, with the special move called a _5 Save_.
 - Additionally, 5's can also be saved indirectly with the special move called a _5 Stall_, which can happen in the _Early Game_ and in other "stalling" situations.
 - So, if a number 5 clue is performed on a 5 that is not on chop, and it is **not** a stalling situation, then it will normally look like a _Play Clue_ on that 5.
-- However, if a 5 is touched with a number 5 clue that happens to be **one-away** from chop, then we agree that it has a special meaning, and that the clue is **not** a _Play Clue_ at all.
+- However, if a 5 is exactly **one-away** from chop, then we agree that it has a special meaning, and that the clue is **not** a _Play Clue_ at all.
 - Instead, we agree that the clue is a _5's Chop Move_, and the player should _Chop Move_ the card to the right of the 5 (similarly to the _Trash Chop Move_).
 - For example, in a 3-player game:
   - All the 1's are played on the stacks.

--- a/docs/level-4.mdx
+++ b/docs/level-4.mdx
@@ -69,9 +69,10 @@ import ChopMovePrompt from "./level-4/chop-move-prompt.yml";
 
 ### The 5's Chop Move (5CM)
 
-- Normally, we are only allowed to save 5's on chop (unless it is done with a _5 Stall_, which can happen in the _Early Game_ and in other "stalling" situations).
+- Normally, **we are only allowed to save 5's that are on chop**, with the special move called a _5 Save_.
+- Additionally, 5's can also be saved indirectly with the special move called a _5 Stall_, which can happen in the _Early Game_ and in other "stalling" situations.
 - So, if a number 5 clue is performed on a 5 that is not on chop, and it is **not** a stalling situation, then it will normally look like a _Play Clue_ on that 5.
-- However, if the 5 is **one-away** from chop (or, if two or more 5's are clued and the rightmost 5 is one-away from chop), then we agree that it has a special meaning, and that the clue is **not** a _Play Clue_ at all.
+- However, if a 5 is touched with a number 5 clue that happens to be **one-away** from chop, then we agree that it has a special meaning, and that the clue is **not** a _Play Clue_ at all.
 - Instead, we agree that the clue is a _5's Chop Move_, and the player should _Chop Move_ the card to the right of the 5 (similarly to the _Trash Chop Move_).
 - For example, in a 3-player game:
   - All the 1's are played on the stacks.

--- a/docs/level-4.mdx
+++ b/docs/level-4.mdx
@@ -71,10 +71,7 @@ import ChopMovePrompt from "./level-4/chop-move-prompt.yml";
 
 - Normally, we are only allowed to save 5's on chop (unless it is done with a _5 Stall_, which can happen in the _Early Game_ and in other "stalling" situations).
 - So, if a number 5 clue is performed on a 5 that is not on chop, and it is **not** a stalling situation, then it will normally look like a _Play Clue_ on that 5.
-- However, if the 5 is:
-  - **one-away** from chop (or, if two or more 5's are clued and the rightmost 5 is one-away from chop), and
-  - the chop card is not a trash card
-- Then, we agree that it has a special meaning, and that the clue is **not** a _Play Clue_ at all.
+- However, if the 5 is **one-away** from chop (or, if two or more 5's are clued and the rightmost 5 is one-away from chop), then we agree that it has a special meaning, and that the clue is **not** a _Play Clue_ at all.
 - Instead, we agree that the clue is a _5's Chop Move_, and the player should _Chop Move_ the card to the right of the 5 (similarly to the _Trash Chop Move_).
 - For example, in a 3-player game:
   - All the 1's are played on the stacks.


### PR DESCRIPTION
The text currently says that a clue is only a 5s Chop Move if the chop is trash. The player receiving the clue is the only one who doesn't know whether their chop is trash, so they can't use that information to interpret the clue.

Remove the requirement for chop to be trash. At level 4, all 5s clues that newly touch a one-before-chop 5 are interpreted as 5s Chop Moves. Players won't do this when the chop is trash.

This eliminates the potential for Alice to give a 5s Play Clue to Claire, finessing Bob. From discussion on Discord, it sounds like players are likely to misinterpret this clue, particularly at level 4: https://discord.com/channels/140016142600241152/1299966501343723540