### PR TITLE
Update duplicitous-tempo-clue.yml

### DIFF
--- a/docs/level-17/duplicitous-tempo-clue.yml
+++ b/docs/level-17/duplicitous-tempo-clue.yml
@@ -20,6 +20,7 @@ players:
         below: plays
       - type: g2
         clue: 2
+        retouched: true
       - type: x
       - type: x
   - cards:


### PR DESCRIPTION
Fixed an image showing a retouched card as newly touched. Section affected: Duplicitous Tempo Clue.