### PR TITLE
Discuss white/gray clue arrows in beginner guide

### DIFF
--- a/docs/beginner/card-layout-2.yml
+++ b/docs/beginner/card-layout-2.yml
@@ -15,6 +15,12 @@ players:
   - cards:
       - type: x
       - type: x
+      - type: x
+      - type: x
+      - type: x
+  - cards:
+      - type: x
+      - type: x
       - type: 1
         clue: 1
       - type: 1

--- a/docs/beginner/card-layout-3.yml
+++ b/docs/beginner/card-layout-3.yml
@@ -1,0 +1,29 @@
+stacks:
+  - r: 0
+  - y: 0
+  - g: 0
+  - b: 0
+  - p: 0
+players:
+  - cards:
+      - type: x
+      - type: x
+      - type: x
+      - type: x
+      - type: x
+  - clueGiver: true
+    cards:
+      - type: x
+      - type: x
+      - type: x
+      - type: x
+      - type: x
+  - cards:
+      - type: b
+        clue: b
+      - type: x
+      - type: 1
+      - type: 1
+        clue: b
+        retouched: true
+      - type: x

--- a/docs/beginner/card-layout.mdx
+++ b/docs/beginner/card-layout.mdx
@@ -5,6 +5,7 @@ title: Card Layout
 import BeginnersGuideProgress from "@site/src/beginnersGuide.tsx";
 import CardLayout1 from "./card-layout-1.yml";
 import CardLayout2 from "./card-layout-2.yml";
+import CardLayout3 from "./card-layout-3.yml";
 
 <BeginnersGuideProgress id="card-layout" />
 
@@ -28,9 +29,14 @@ In this guide, there will be some images to show off the concepts introduced.
 ## Clues
 
 - Arrows indicate that a card was "touched" by the last clue that was given.
-- Clued cards will have permanent yellow borders around them.
+- Clued cards will have permanent yellow borders around them. Unclued cards will not have these yellow borders.
 
 <CardLayout2 />
+
+- When a card is "touched" by a clue for the first time, a white arrow will point to the card and a yellow border will be applied. 
+- When an already-clued card is "retouched" by subsequent clues, a gray arrow will point to the card instead.
+
+<CardLayout3 />
 
 ## Challenge Questions
 

--- a/docs/beginner/card-layout.mdx
+++ b/docs/beginner/card-layout.mdx
@@ -33,7 +33,7 @@ In this guide, there will be some images to show off the concepts introduced.
 
 <CardLayout2 />
 
-- When a card is "touched" by a clue for the first time, a white arrow will point to the card and a yellow border will be applied. 
+- When a card is "touched" by a clue for the first time, a white arrow will point to the card and a yellow border will be applied.
 - When an already-clued card is "retouched" by subsequent clues, a gray arrow will point to the card instead.
 
 <CardLayout3 />

--- a/docs/beginner/card-layout.mdx
+++ b/docs/beginner/card-layout.mdx
@@ -34,7 +34,7 @@ In this guide, there will be some images to show off the concepts introduced.
 <CardLayout2 />
 
 - When a card is "touched" by a clue for the first time, a white arrow will point to the card and a yellow border will be applied.
-- When an already-clued card is "retouched" by subsequent clues, a gray arrow will point to the card instead.
+- When an already-clued card is "retouched" by subsequent clues, a gray arrow will point to the card.
 
 <CardLayout3 />
 

--- a/docs/beginner/single-card-focus.mdx
+++ b/docs/beginner/single-card-focus.mdx
@@ -19,6 +19,8 @@ import ChopFocus from "./chop-focus.yml";
 
 - When determining the _focus_ of a clue, you need to look for "new" cards.
 - New cards are specifically defined as **cards that are touched by a clue that did not have any clues "on" them already**.
+- If a clue touches new cards, the new cards will always have white arrows pointing to them.
+- If any already-clued cards are touched again by a clue, the already-clued cards will always have gray arrows pointing to them.
 
 ### Determining the Focus: 4 Steps
 

--- a/docs/beginner/single-card-focus.mdx
+++ b/docs/beginner/single-card-focus.mdx
@@ -19,8 +19,6 @@ import ChopFocus from "./chop-focus.yml";
 
 - When determining the _focus_ of a clue, you need to look for "new" cards.
 - New cards are specifically defined as **cards that are touched by a clue that did not have any clues "on" them already**.
-- If a clue touches new cards, the new cards will always have white arrows pointing to them.
-- If any already-clued cards are touched again by a clue, the already-clued cards will always have gray arrows pointing to them.
 
 ### Determining the Focus: 4 Steps
 


### PR DESCRIPTION
Added a small section in "Card Layout" to introduce the gray arrow for retouches. Also added a small section in "Single Card Focus" explaining new=white and old=gray if retouched.