### PR TITLE
Update level-9.mdx

### DIFF
--- a/docs/level-9.mdx
+++ b/docs/level-9.mdx
@@ -122,7 +122,7 @@ import FiveStall from "./level-9/five-stall.yml";
 - Normally, you are only allowed to perform a _5 Stall_ if:
   - it is currently a valid _Stalling Situation_
   - there are no normal _Play Clues_ or normal _Save Clues_ to give
-- However, as an exception, players are allowed to _5 Stall_ if they are in a valid _Stalling Situation_ and there is **only one** _Play Clue_ remaining to give and it would touch a card that someone else on the team could possibly _Finesse_. We refer to this as the _Finesse Position Exception_, or FPE for short.
+- However, as an exception, players are also allowed to _5 Stall_ in a _Stalling Situations_ if there is **only one** _Play Clue_ remaining to give and it would touch a card that someone else on the team could possibly _Finesse_. We refer to this as the _Finesse Position Exception_, or FPE for short.
 - Some situations where someone else could not _Finesse_ the card in question are:
   1. when the card would move off of _Finesse Position_ due to the holder playing another card
   1. when there would be no clues remaining after the _5 Stall_

--- a/docs/level-9.mdx
+++ b/docs/level-9.mdx
@@ -122,7 +122,7 @@ import FiveStall from "./level-9/five-stall.yml";
 - Normally, you are only allowed to perform a _5 Stall_ if:
   - it is currently a valid _Stalling Situation_
   - there are no normal _Play Clues_ or normal _Save Clues_ to give
-- However, as an exception, players are also allowed to _5 Stall_ in a _Stalling Situations_ if there is **only one** _Play Clue_ remaining to give and it would touch a card that someone else on the team could possibly _Finesse_. We refer to this as the _Finesse Position Exception_, or FPE for short.
+- However, as an exception, players are also allowed to _5 Stall_ in a _Stalling Situations_ if there is **only one** _Play Clue_ remaining to give and it would touch a card on _Finesse Position_ that someone else on the team could possibly _Finesse_. We refer to this as the _Finesse Position Exception_, or FPE for short.
 - Some situations where someone else could not _Finesse_ the card in question are:
   1. when the card would move off of _Finesse Position_ due to the holder playing another card
   1. when there would be no clues remaining after the _5 Stall_

--- a/docs/level-9.mdx
+++ b/docs/level-9.mdx
@@ -120,14 +120,11 @@ import FiveStall from "./level-9/five-stall.yml";
 ### The 5 Stall Finesse Position Exception (FPE)
 
 - Normally, you are only allowed to perform a _5 Stall_ if:
-  - it is currently a valid _Stalling Situation_
-  - there are no normal _Play Clues_ or normal _Save Clues_ to give
+  1. it is currently a valid _Stalling Situation_
+  1. there are no normal _Play Clues_ or normal _Save Clues_ to give
 - However, as an exception, players are also allowed to _5 Stall_ in a _Stalling Situations_ if there is **only one** _Play Clue_ remaining to give and it would touch a card on _Finesse Position_ that someone else on the team could possibly _Finesse_. We refer to this as the _Finesse Position Exception_, or FPE for short.
-- Some situations where someone else could not _Finesse_ the card in question are:
-  1. when the card would move off of _Finesse Position_ due to the holder playing another card
-  1. when there would be no clues remaining after the _5 Stall_
+- The _Finesse Position Exception_ does not apply every time there is a playable card on _Finesse Position_. It only applies when there is a card on _Finesse Position_ that can actually be _Finessed_ or "gotten" by someone else. (For example, it would not apply if a player was using the last clue to _5 Stall_.)
 - The _Finesse Position Exception_ **only applies to _5 Stalls_**. Therefore, you cannot ever use the _Finesse Position Exception_ as an excuse to end the _Early Game_.
-- The _Finesse Position Exception_ does not apply every time there is a playable card on _Finesse Position_. It only applies when there is a card on _Finesse Position_ that can actually be _Finessed_ or "gotten" by someone else. Thus, it does not apply when there is only one clue remaining or when the card would move off _Finesse Position_ due to that player playing another card.
 - The _Finesse Position Exception_ applies if the same card is in multiple _Finesse Positions_ and there is nothing else to do.
 - The _Finesse Position Exception_ applies whenever a player can perform a _5 Stall_, regardless of whether it is the _Early Game_ or the _Mid-Game_.
 

--- a/docs/level-9.mdx
+++ b/docs/level-9.mdx
@@ -122,9 +122,12 @@ import FiveStall from "./level-9/five-stall.yml";
 - Normally, you are only allowed to perform a _5 Stall_ if:
   - it is currently a valid _Stalling Situation_
   - there are no normal _Play Clues_ or normal _Save Clues_ to give
-- However, as an exception, players are allowed to _5 Stall_ if there is **only one** _Play Clue_ to give remaining and it would touch a card that someone else on the team could possibly _Finesse_. We refer to this as the _Finesse Position Exception_, or FPE for short.
+- However, as an exception, players are allowed to _5 Stall_ if they are in a valid _Stalling Situation_ and there is **only one** _Play Clue_ remaining to give and it would touch a card that someone else on the team could possibly _Finesse_. We refer to this as the _Finesse Position Exception_, or FPE for short.
+- Some situations where someone else could not _Finesse_ the card in question are:
+  1. when the card would move off of _Finesse Position_ due to the holder playing another card
+  1. when there would be no clues remaining after the _5 Stall_
 - The _Finesse Position Exception_ **only applies to _5 Stalls_**. Therefore, you cannot ever use the _Finesse Position Exception_ as an excuse to end the _Early Game_.
-- The _Finesse Position Exception_ does not apply every time there is a playable card on _Finesse Position_. It only applies when there is a card on _Finesse Position_ that can actually be _Finessed_ or "gotten" by someone else.
+- The _Finesse Position Exception_ does not apply every time there is a playable card on _Finesse Position_. It only applies when there is a card on _Finesse Position_ that can actually be _Finessed_ or "gotten" by someone else. Thus, it does not apply when there is only one clue remaining or when the card would move off _Finesse Position_ due to that player playing another card.
 - The _Finesse Position Exception_ applies if the same card is in multiple _Finesse Positions_ and there is nothing else to do.
 - The _Finesse Position Exception_ applies whenever a player can perform a _5 Stall_, regardless of whether it is the _Early Game_ or the _Mid-Game_.
 

--- a/docs/level-9.mdx
+++ b/docs/level-9.mdx
@@ -123,10 +123,15 @@ import FiveStall from "./level-9/five-stall.yml";
   1. it is currently a valid _Stalling Situation_
   1. there are no normal _Play Clues_ or normal _Save Clues_ to give
 - However, as an exception, players are also allowed to _5 Stall_ in a _Stalling Situations_ if there is **only one** _Play Clue_ remaining to give and it would touch a card on _Finesse Position_ that someone else on the team could possibly _Finesse_. We refer to this as the _Finesse Position Exception_, or FPE for short.
-- The _Finesse Position Exception_ does not apply every time there is a playable card on _Finesse Position_. It only applies when there is a card on _Finesse Position_ that can actually be _Finessed_ or "gotten" by someone else. (For example, it would not apply if a player was using the last clue to _5 Stall_.)
-- The _Finesse Position Exception_ **only applies to _5 Stalls_**. Therefore, you cannot ever use the _Finesse Position Exception_ as an excuse to end the _Early Game_.
 - The _Finesse Position Exception_ applies if the same card is in multiple _Finesse Positions_ and there is nothing else to do.
 - The _Finesse Position Exception_ applies whenever a player can perform a _5 Stall_, regardless of whether it is the _Early Game_ or the _Mid-Game_.
+- The _Finesse Position Exception_ **only applies to _5 Stalls_**. Therefore, you cannot use the _Finesse Position Exception_ as an excuse to end the _Early Game_.
+- The _Finesse Position Exception_ **only applies** when the playable card on _Finesse Position_ can actually be _Finessed_ or "gotten" by someone else. For example, it would not apply in a situation like this:
+  - It is the _Early Game_ and there is one clue left.
+  - Alice sees that Bob has an unclued, off-chop 5.
+  - Alice sees that Cathy has a unclued playable card in her _Finesse Position_.
+  - Alice knows that in a hypothetical where she uses the last clue to give a _5 Stall_ to Bob, then Bob would be at 0 clues and would have to discard, and then it would be Cathy's turn, and then Cathy would either clue or discard.
+  - In this hypothetical, it would get to Cathy's turn before anyone on the team had a chance to _Finesse_ Cathy's _Finesse Position_ card. Thus, the _Finesse Position Exception_ would not apply. Subsequently, it would be illegal for Alice to perform a _5 Stall_, so Alice must clue Cathy's _Finesse Position_ card directly.
 
 ### The Locked Hand Save (LHS)
 


### PR DESCRIPTION
Clarifies when FPE is allowed, based on my understanding of it.

I had a few games where it was thought that FPE can be done in any situation where there is only one Play Clue left to give and it would possibly be killing someone's Finesse. I thought this myself, once, until I got questioned heavily in review lol.

However it seems that FPE is only meant to be used in the case that the user is already in a Stalling Situation. If true, I suggest we add something saying that FPE only applies when already in a Stalling Situation and cannot be used to create one from thin air.