### PR TITLE
Remove reference to Context in Clarity Principle

### DIFF
--- a/docs/level-6.mdx
+++ b/docs/level-6.mdx
@@ -81,7 +81,6 @@ import DiscardModulation from "./level-6/discard-modulation.yml";
 
 ### Clarity Principle
 
-- First, see the section on _[Context](level-12.mdx#context)_.
 - In the H-Group, we like to find the "best" move for every turn in the post-game review. This is fun and helps everybody improve. But this can be taken too far.
 - Sometimes, players will give clues that are very complicated. Maybe the clue looks like it could be two different moves. Or, maybe the clue relies on non-obvious contextual factors.
 - Often, these kinds of complicated clues end up in misplays and lost games. And in the post-game review, the person who gave the clue gets defensive: "If you guys just played perfectly, then my clue would have worked!"


### PR DESCRIPTION
Since Clarity Principle has been moved to Level 6, it seems that linking to a section on a later level is unnecessary, especially since the text still makes sense without the link.