### PR TITLE
Update play-clues.mdx

### DIFF
--- a/docs/extras/play-clues.mdx
+++ b/docs/extras/play-clues.mdx
@@ -28,7 +28,7 @@ title: Play Clues
 
 ### The Load Clue
 
-- The _Load Clue_ is covered at [level 20](../level-25.mdx#the-load-clue).
+- The _Load Clue_ is covered at [level 25](../level-25.mdx#the-load-clue).
 
 ### The Negative 5's Tempo Clue (or Inverted 5's Tempo Clue)
 


### PR DESCRIPTION
The load clue is in the priority section which moved to level 25 (and thus is not in lvl 20 anymore).