### PR TITLE
Update level-14.mdx - RTF with Crit/5 card not possible

### DIFF
--- a/docs/level-14.mdx
+++ b/docs/level-14.mdx
@@ -107,6 +107,7 @@ import TrashPush from "./level-14/trash-push.yml";
 
 <ReverseTrashFinesse />
 
+- Cluing trash as a **critical** or a **5** card does **not** trigger a _Reverse Trash Finesse_, since discarding trash (known to the clue-receiver) as a _Gentleman's Discard_ on a card that only has one single copy is nonsensical. It triggers a _[Trash Touch Elimination](level-18.mdx#trash-touch-elimination-tte)_ instead, a level 18 move.
 - Note that _Reverse Trash Finesses_ should not always be entertained and **depend on context**. Specifically, towards the end of the game, _Reverse Trash Finesses_ are "turned off". This is because towards the end of the game, the team needs _Tempo_, and _Reverse Trash Finesses_ are slow and require even more discarding.
 
 ### The Forced Gentleman's Discard Chop Move

--- a/docs/level-14.mdx
+++ b/docs/level-14.mdx
@@ -107,8 +107,8 @@ import TrashPush from "./level-14/trash-push.yml";
 
 <ReverseTrashFinesse />
 
-- Cluing trash as a **critical** or a **5** card does **not** trigger a _Reverse Trash Finesse_, since discarding trash (known to the clue-receiver) as a _Gentleman's Discard_ on a card that only has one single copy is nonsensical. It triggers a _[Trash Touch Elimination](level-18.mdx#trash-touch-elimination-tte)_ instead, a level 18 move.
 - Note that _Reverse Trash Finesses_ should not always be entertained and **depend on context**. Specifically, towards the end of the game, _Reverse Trash Finesses_ are "turned off". This is because towards the end of the game, the team needs _Tempo_, and _Reverse Trash Finesses_ are slow and require even more discarding.
+- For level 18 players, note that Reverse Trash Finesses can conflict with [Trash Touch Elimination](level-18.mdx#trash-touch-elimination-tte). Specifically, if the represented card satisfies the "1 copy left" rule, then the Reverse Trash Finesse will no longer work and the person with the critical card will write _Trash Touch Elimination Notes_ instead.
 
 ### The Forced Gentleman's Discard Chop Move
 


### PR DESCRIPTION
To avoid confusion between RTF and TTE, I propose that RTF with a crit/5 card should be delegalized, since RTF contains a forced GD element which does not make sense when there is only one copy of the card left. This also preserves the 'only one missing card' condition of TTE.