### PR TITLE
Add colours to the yes/no nodes for clue focus

### DIFF
--- a/docs/level-1.mdx
+++ b/docs/level-1.mdx
@@ -73,6 +73,9 @@ D3N(No)
 D3YL([The focus is on the chop card.])
 D3NL([The focus is on the left-most card.])
 
+class D1Y,D2Y,D3Y node-yes
+class D1N,D2N,D3N node-no
+
 S --> D1;
 D1 --> D1Y;
 D1 --> D1N;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -17,6 +17,8 @@
   --ifm-color-primary-lightest: #e5b4ab;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --flowchart-yes: #88ff88;
+  --flowchart-no: #ff8888;
 
   /* Hack to increase the spacing between header elements */
   /* (the Infima class name was determined by looking at the CSS calculation in Chrome dev-tools) */
@@ -35,6 +37,8 @@
   --ifm-color-primary-lightest: #e5b4ab;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  --flowchart-yes: #008800;
+  --flowchart-no: #880000;
 }
 
 /* ------------------------------------- */
@@ -131,4 +135,13 @@ svg.example text.site-theme-text {
   top: 4em;
   width: 6em;
   height: 6em;
+}
+
+/* In order to override the default styling from Mermaid, we need to provide an ID. The outermost <div> has a known ID. */
+#__docusaurus g.node-yes > rect {
+  fill: var(--flowchart-yes);
+}
+
+#__docusaurus g.node-no > rect {
+  fill: var(--flowchart-no);
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -17,6 +17,8 @@
   --ifm-color-primary-lightest: #e5b4ab;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+
+  /* Flowchart classes for light theme */
   --flowchart-yes: #88ff88;
   --flowchart-no: #ff8888;
 
@@ -37,6 +39,8 @@
   --ifm-color-primary-lightest: #e5b4ab;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+
+  /* Flowchart classes for dark theme */  
   --flowchart-yes: #008800;
   --flowchart-no: #880000;
 }


### PR DESCRIPTION
This commit demonstrates how to set node background colours from outside the flowchart definitions, with minimal extra code needed within the flowchart itself.

Inside the flowchart, we need a line for each CSS class we want to add to nodes within the chart. In the global CSS file, we define colours as variables and apply those colours.

This is intended as a proof-of-concept, rather than as a final version. I have not put much thought into whether the colours are good; I merely wanted them to be clearly present and based on the user's light/dark preference.

![image](https://github.com/user-attachments/assets/361750ee-2220-4bcc-b815-6ca40335960a)

![image](https://github.com/user-attachments/assets/82749cfb-e1ba-4a9c-aa23-8fdddcf049ae)
