### PR TITLE
Formalizing Known-Trash Discard Order with Trash from UTD/UDD and other minor tweaks

### DIFF
--- a/docs/level-14.mdx
+++ b/docs/level-14.mdx
@@ -14,7 +14,7 @@ import TrashPush from "./level-14/trash-push.yml";
 
 - Sometimes, players will have two or more clued known-trash cards in their hand. (And everyone on the team can equally see that they are known-trash.)
 - In this situation, players are expected to discard the leftmost trash card.
-  - The rare exception to this is if [the trash came from an _Unknown Trash Discharge_ or _Unknown Dupe Discharge_](level-16.mdx#known-trash-discard-order-after-a-utdudd). In that case, those cards must be discarded first.
+  - For level 16 players, know that the exception to this is if [the trash came from an [_Unknown Trash Discharge_](level-16.mdx#the-unknown-trash-discharge-1-for-1-form-utd) or an [_Unknown Dupe Discharge_](level-16.mdx#the-unknown-dupe-discharge-udd). In that case, those cards must be discarded first.
 
 ## Special Moves
 

--- a/docs/level-14.mdx
+++ b/docs/level-14.mdx
@@ -20,7 +20,7 @@ import TrashPush from "./level-14/trash-push.yml";
 
 ### The Trash Order Chop Move (TOCM)
 
-- First, see the section on the _[Known-Trash Discard Order](level-14.mdx#known-trash-discard-order)_ and the _[Order Chop Move](level-4.mdx#the-order-chop-move-ocm)_.
+- First, see the section on the _[Known-Trash Discard Order](#known-trash-discard-order)_ and the _[Order Chop Move](level-4.mdx#the-order-chop-move-ocm)_.
 - If a player skips over their leftmost trash card and instead discards the second leftmost trash card, they must be trying to communicate something extra.
 - This means that the next player should _Chop Move_ (in a manner similar to a _Order Chop Move_).
 - Note that a player is not necessarily trying to perform a _Trash Order Chop Move_ if the two trash cards have different kinds of clues on them. For example, by discarding specific trash cards, it can communicate that the player "sees" all of the non-trash possibilities of that card.

--- a/docs/level-14.mdx
+++ b/docs/level-14.mdx
@@ -14,7 +14,7 @@ import TrashPush from "./level-14/trash-push.yml";
 
 - Sometimes, a player will have two or more clued known-trash cards in their hand. (And everyone on the team can equally see that they are known-trash.)
 - In this situation, the player is expected to discard the newest (leftmost) trash card.
-- The **[exception to the known-trash discard order](level-16.mdx#known-trash-discard-order-after-a-utdudd)** is the trash that comes from an _Unknown Trash Discharge_ or _Unknown Dupe Discharge_.
+  - The rare exception to this is if [the trash came from an _Unknown Trash Discharge_ or _Unknown Dupe Discharge_](level-16.mdx#known-trash-discard-order-after-a-utdudd). In that case, those cards must be discarded first.
 
 ## Special Moves
 

--- a/docs/level-14.mdx
+++ b/docs/level-14.mdx
@@ -8,14 +8,20 @@ import TrashFinesseTwoCards from "./level-14/trash-finesse-two-cards.yml";
 import ReverseTrashFinesse from "./level-14/reverse-trash-finesse.yml";
 import TrashPush from "./level-14/trash-push.yml";
 
+## Conventions
+
+### Known-Trash Discard Order
+
+- Sometimes, a player will have two clued known-trash cards in their hand (and these cards are explicitly known-trash, meaning that everyone on the team can equally see that they are known-trash).
+- In this situation, the player is expected to discard the newest (leftmost) trash card.
+- The **[exception to the known-trash discard order](level-16.mdx#known-trash-discard-order-after-a-utdudd)** is the trash that comes from an _Unknown Trash Discharge_ or _Unknown Dupe Discharge_.
+
 ## Special Moves
 
 ### The Trash Order Chop Move (TOCM)
 
-- First, see the section on the _[Order Chop Move](level-4.mdx#the-order-chop-move-ocm)_.
-- Sometimes, a player will have two clued known-trash cards in their hand (and these cards are explicitly known-trash, meaning that everyone on the team can equally see that they are known-trash).
-- In this situation, the player is expected to discard the newest (leftmost) trash card.
-- Thus, if a player skips over their newest trash card and instead discards the second newest trash card, they must be trying to communicate something extra.
+- First, see the section on the _[Known-Trash Discard Order](level-14.mdx#known-trash-discard-order)_ and the _[Order Chop Move](level-4.mdx#the-order-chop-move-ocm)_.
+- If a player skips over their newest trash card and instead discards the second newest trash card, they must be trying to communicate something extra.
 - This means that the next player should _Chop Move_ (in a manner similar to a _Order Chop Move_).
 - Note that a player is not necessarily trying to perform a _Trash Order Chop Move_ if the two trash cards have different kinds of clues on them. For example, by discarding specific trash cards, it can communicate that the player "sees" all of the non-trash possibilities of that card.
 
@@ -23,7 +29,6 @@ import TrashPush from "./level-14/trash-push.yml";
 
 - First, see the sections on the _[Shout Discard Chop Move](level-7.mdx#the-shout-discard-chop-move)_ and the _[Trash Order Chop Move](level-14.mdx#the-trash-order-chop-move-tocm)_.
 - If a player has a known-playable card and multiple known-trash cards, then discarding a trash card other than the expected trash card causes a skip in exactly the same way as a _Trash Order Chop Move_.
-  - As discussed in previous levels, the discard order for trash is from left to right. The exception is with trash that comes from an _Unknown Trash Discharge_ or _Unknown Dupe Discharge_. In that case, the focus is discarded first.
 - For example, in a 3-player game:
   - Alice has a known playable card on slot 1, a known trash card on slot 2, and a known trash card on slot 3.
   - If Alice plays her known playable card from slot 1, nothing special happens.

--- a/docs/level-14.mdx
+++ b/docs/level-14.mdx
@@ -12,8 +12,8 @@ import TrashPush from "./level-14/trash-push.yml";
 
 ### Known-Trash Discard Order
 
-- Sometimes, a player will have two or more clued known-trash cards in their hand. (And everyone on the team can equally see that they are known-trash.)
-- In this situation, the player is expected to discard the newest (leftmost) trash card.
+- Sometimes, players will have two or more clued known-trash cards in their hand. (And everyone on the team can equally see that they are known-trash.)
+- In this situation, players are expected to discard the leftmost trash card.
   - The rare exception to this is if [the trash came from an _Unknown Trash Discharge_ or _Unknown Dupe Discharge_](level-16.mdx#known-trash-discard-order-after-a-utdudd). In that case, those cards must be discarded first.
 
 ## Special Moves
@@ -21,7 +21,7 @@ import TrashPush from "./level-14/trash-push.yml";
 ### The Trash Order Chop Move (TOCM)
 
 - First, see the section on the _[Known-Trash Discard Order](level-14.mdx#known-trash-discard-order)_ and the _[Order Chop Move](level-4.mdx#the-order-chop-move-ocm)_.
-- If a player skips over their newest trash card and instead discards the second newest trash card, they must be trying to communicate something extra.
+- If a player skips over their leftmost trash card and instead discards the second leftmost trash card, they must be trying to communicate something extra.
 - This means that the next player should _Chop Move_ (in a manner similar to a _Order Chop Move_).
 - Note that a player is not necessarily trying to perform a _Trash Order Chop Move_ if the two trash cards have different kinds of clues on them. For example, by discarding specific trash cards, it can communicate that the player "sees" all of the non-trash possibilities of that card.
 

--- a/docs/level-14.mdx
+++ b/docs/level-14.mdx
@@ -12,7 +12,7 @@ import TrashPush from "./level-14/trash-push.yml";
 
 ### Known-Trash Discard Order
 
-- Sometimes, a player will have two clued known-trash cards in their hand (and these cards are explicitly known-trash, meaning that everyone on the team can equally see that they are known-trash).
+- Sometimes, a player will have two or more clued known-trash cards in their hand. (And everyone on the team can equally see that they are known-trash.)
 - In this situation, the player is expected to discard the newest (leftmost) trash card.
 - The **[exception to the known-trash discard order](level-16.mdx#known-trash-discard-order-after-a-utdudd)** is the trash that comes from an _Unknown Trash Discharge_ or _Unknown Dupe Discharge_.
 

--- a/docs/level-16.mdx
+++ b/docs/level-16.mdx
@@ -134,7 +134,6 @@ import UnknownDupeDischarge from "./level-16/unknown-dupe-discharge.yml";
 - _Unknown Dupe Discharges_ can be initiated with either color clues or number clues.
 - _Unknown Dupe Discharges_ only apply if **the two duplicated cards are in the same person's hand**.
   - It is explicitly illegal to perform an _Unknown Dupe Discharge_ that duplicates a card in someone else's hand. If this happens, the clue must have some other meaning.
-- Players are still expected to discard **focus-first** even in the case where it is globally known that the clued cards are duplicated cards. This is because in general, it can be hard to tell if the clue receiver knows that an _Unknown Dupe Discharge_ has occurred, because it could have been an _Unknown Trash Discharge_, in which case only the focus is discardable. Discarding focus-first in all cases avoids desync on whether the clue receiver knows they hold dupes or simply trash.
   - In this special case, if a player still chooses to discard the non-focused dupe, they must be intending to send a deeper message. Such a discard should be treated as a _Trash Order Chop Move_.
 - Remember that after an _Unknown Dupe Discharge_, the player who received the clue is supposed to _discard the focus of the clue_, even before other known trash to the left of it.
   - However, in the case where only two new cards are touched, then the player who received the clue may know that both of these cards must be the same. In this special case, they can discard the non-focused card to cause a _Trash Order Chop Move_.

--- a/docs/level-16.mdx
+++ b/docs/level-16.mdx
@@ -136,13 +136,7 @@ import UnknownDupeDischarge from "./level-16/unknown-dupe-discharge.yml";
   - It is explicitly illegal to perform an _Unknown Dupe Discharge_ that duplicates a card in someone else's hand. If this happens, the clue must have some other meaning.
 - Players are still expected to discard **focus-first** even in the case where it is globally known that the clued cards are duplicated cards. This is because in general, it can be hard to tell if the clue receiver knows that an _Unknown Dupe Discharge_ has occurred, because it could have been an _Unknown Trash Discharge_, in which case only the focus is discardable. Discarding focus-first in all cases avoids desync on whether the clue receiver knows they hold dupes or simply trash.
   - In this special case, if a player still chooses to discard the non-focused dupe, they must be intending to send a deeper message. Such a discard should be treated as a _Trash Order Chop Move_.
-
-## General Principles
-
-- Note that if an _Unknown Trash/Dupe Discharge_ is initiated by a 1 clue, the focus of the clue is determined by the _[Play Order of Multiple Unknown 1s](level-3.mdx#playing-multiple-1s)_.
-
-### Known-Trash Discard Order after a UTD/UDD
-
-- Remember that after an _Unknown Trash/Dupe Discharge_, the player who received the clue is supposed to _discard the focus of the clue_, even before other known-trash to the left of it.
-- Hence if a player discards the left-most trash instead of trash from a known _UTD_ or unknown _UDD_, it is a _Trash Order Chop Move_ on Bob.
-- If a player discards the left-most trash instead of trash from a known _UDD_, it is a _Trash Order Chop Move_ on Cathy.
+- Remember that after an _Unknown Dupe Discharge_, the player who received the clue is supposed to _discard the focus of the clue_, even before other known trash to the left of it.
+  - However, in the case where only two new cards are touched, then the player who received the clue may know that both of these cards must be the same. In this special case, they can discard the non-focused card to cause a _Trash Order Chop Move_.
+  - Note that if the _Unknown Dupe Discharge_ was initiated by a chop-focus clue, this means that the expected discard order is thus different from the usual 'left to right' order, since in that case, the focus of the clue will be rightmost.
+  - Players are also expected to discard focus-first even in the case where it is globally known that the clued cards are duplicated cards. This is because in general, it can be hard to tell if the clue receiver knows that an _Unknown Dupe Discharge_ has occurred, because it could have been an _Unknown Trash Discharge_, in which case only the focus is discardable. Discarding focus-first in all cases avoids desync on whether the clue receiver knows they hold dupes or simply trash.

--- a/docs/level-16.mdx
+++ b/docs/level-16.mdx
@@ -134,7 +134,15 @@ import UnknownDupeDischarge from "./level-16/unknown-dupe-discharge.yml";
 - _Unknown Dupe Discharges_ can be initiated with either color clues or number clues.
 - _Unknown Dupe Discharges_ only apply if **the two duplicated cards are in the same person's hand**.
   - It is explicitly illegal to perform an _Unknown Dupe Discharge_ that duplicates a card in someone else's hand. If this happens, the clue must have some other meaning.
-- Remember that after an _Unknown Dupe Discharge_, the player who received the clue is supposed to _discard the focus of the clue_, even before other known trash to the left of it.
-  - However, in the case where only two new cards are touched, then the player who received the clue may know that both of these cards must be the same. In this special case, they can discard the non-focused card to cause a _Trash Order Chop Move_.
-  - Note that if the _Unknown Dupe Discharge_ was initiated by a chop-focus clue, this means that the expected discard order is thus different from the usual 'left to right' order, since in that case, the focus of the clue will be rightmost.
-  - Players are also expected to discard focus-first even in the case where it is globally known that the clued cards are duplicated cards. This is because in general, it can be hard to tell if the clue receiver knows that an _Unknown Dupe Discharge_ has occurred, because it could have been an _Unknown Trash Discharge_, in which case only the focus is discardable. Discarding focus-first in all cases avoids desync on whether the clue receiver knows they hold dupes or simply trash.
+- Players are still expected to discard **focus-first** even in the case where it is globally known that the clued cards are duplicated cards. This is because in general, it can be hard to tell if the clue receiver knows that an _Unknown Dupe Discharge_ has occurred, because it could have been an _Unknown Trash Discharge_, in which case only the focus is discardable. Discarding focus-first in all cases avoids desync on whether the clue receiver knows they hold dupes or simply trash.
+  - In this special case, if a player still chooses to discard the non-focused dupe, they must be intending to send a deeper message. Such a discard should be treated as a _Trash Order Chop Move_.
+
+## General Principles
+
+- Note that if an _Unknown Trash/Dupe Discharge_ is initiated by a 1 clue, the focus of the clue is determined by the _[Play Order of Multiple Unknown 1s](level-3.mdx#playing-multiple-1s)_.
+
+### Known-Trash Discard Order after a UTD/UDD
+
+- Remember that after an _Unknown Trash/Dupe Discharge_, the player who received the clue is supposed to _discard the focus of the clue_, even before other known-trash to the left of it.
+- Hence if a player discards the left-most trash instead of trash from a known _UTD_ or unknown _UDD_, it is a _Trash Order Chop Move_ on Bob.
+- If a player discards the left-most trash instead of trash from a known _UDD_, it is a _Trash Order Chop Move_ on Cathy.

--- a/docs/level-16.mdx
+++ b/docs/level-16.mdx
@@ -134,7 +134,6 @@ import UnknownDupeDischarge from "./level-16/unknown-dupe-discharge.yml";
 - _Unknown Dupe Discharges_ can be initiated with either color clues or number clues.
 - _Unknown Dupe Discharges_ only apply if **the two duplicated cards are in the same person's hand**.
   - It is explicitly illegal to perform an _Unknown Dupe Discharge_ that duplicates a card in someone else's hand. If this happens, the clue must have some other meaning.
-  - In this special case, if a player still chooses to discard the non-focused dupe, they must be intending to send a deeper message. Such a discard should be treated as a _Trash Order Chop Move_.
 - Remember that after an _Unknown Dupe Discharge_, the player who received the clue is supposed to _discard the focus of the clue_, even before other known trash to the left of it.
   - However, in the case where only two new cards are touched, then the player who received the clue may know that both of these cards must be the same. In this special case, they can discard the non-focused card to cause a _Trash Order Chop Move_.
   - Note that if the _Unknown Dupe Discharge_ was initiated by a chop-focus clue, this means that the expected discard order is thus different from the usual 'left to right' order, since in that case, the focus of the clue will be rightmost.


### PR DESCRIPTION
This commit:
- Formalizes Known Trash Discard Order in Lvl 14.
- Highlights the convention of discarding trash from UTD/UDD before other known-trash cards in Lvl 14 (which I feel isn't visible enough) as well as integrates it into a revised Known-Trash Discard Order at Lvl 16 (per discussion here: https://discord.com/channels/140016142600241152/1320870710087913522).
- Declutters the last few bullet points of UDD (per my question here: https://discord.com/channels/140016142600241152/1320872790034743376).
- Adds a remark at the end of Lvl 16 for finding the focus of a 1 clue when it touches multiple unknown 1s.