### PR TITLE
Fixing minor typo in level3

### DIFF
--- a/docs/level-3.mdx
+++ b/docs/level-3.mdx
@@ -37,7 +37,7 @@ import InformationLock from "./level-3/information-lock.yml";
 #### Part 2 - The Fresh 1's Rule
 
 - The previous section applies when all of the clued 1s were present in the starting hand. In other words, if one or more 1s are clued that were not in the starting hand, then you would play them as normal from left-to-right.
-- However, what if there is a **mix** of staring hand 1s and non-starting hand 1s? Then, things get a little more complicated.
+- However, what if there is a **mix** of starting hand 1s and non-starting hand 1s? Then, things get a little more complicated.
 - In this situation, we call the non-starting hand 1s "fresh" 1s. It makes sense that fresh 1s would be more important than non-fresh 1s, because otherwise the non-fresh 1s might have been clued earlier.
 - Thus, freshly drawn 1's should always be played before non-fresh 1's.
 - Continuing on from the example in the previous section, imagine that:


### PR DESCRIPTION
This PR fixes a minor typo in the **Fresh 1s Rules** section of Level 3.
It changes `staring` into `starting`.