### PR TITLE
Reword out-of-order condition on tempo clues

### DIFF
--- a/docs/level-6.mdx
+++ b/docs/level-6.mdx
@@ -20,7 +20,7 @@ import DiscardModulation from "./level-6/discard-modulation.yml";
 
 - In some special situations, _Tempo Clues_ have enough value to justify giving them:
   1. When everyone knows it gets two or more clued cards to play (in total across all hands).
-  1. When the clued card cannot be _Prompted_ (because there is another unplayable clued card in the hand that would "block" the _Prompt_).
+  1. When the clued card is not a 5 and cannot be _Prompted_ (because there is another unplayable clued card in the hand that would misplay if the _Prompt_ was attempted).
   1. When playing the clued card would "unlock" someone's hand. (For level 9 players, see the section on [_Locked Hands_](level-9.mdx#the-locked-hand-save-lhs).)
 - If a _Tempo Clue_ is given in any of these situations, it is considered to be "valuable".
 - _Valuable Tempo Clues_ can be given at any time. They don't have any special rules associated with them and they are treated in exactly the same way a "normal" _Play Clue_ is.

--- a/docs/level-6.mdx
+++ b/docs/level-6.mdx
@@ -20,7 +20,7 @@ import DiscardModulation from "./level-6/discard-modulation.yml";
 
 - In some special situations, _Tempo Clues_ have enough value to justify giving them:
   1. When everyone knows it gets two or more clued cards to play (in total across all hands).
-  1. When the clued card is not a 5 and it is "out of order" (meaning that it is not possible for a _Prompt_ to get the card played at this moment in time).
+  1. When the clued card can't be _Prompted_ because another card is blocking it (such as when g2 and g3 are "out of order" and both already clued with green).
   1. When playing the clued card would "unlock" someone's hand. (For level 9 players, see the section on [_Locked Hands_](level-9.mdx#the-locked-hand-save-lhs).)
 - If a _Tempo Clue_ is given in any of these situations, it is considered to be "valuable".
 - _Valuable Tempo Clues_ can be given at any time. They don't have any special rules associated with them and they are treated in exactly the same way a "normal" _Play Clue_ is.

--- a/docs/level-6.mdx
+++ b/docs/level-6.mdx
@@ -20,7 +20,7 @@ import DiscardModulation from "./level-6/discard-modulation.yml";
 
 - In some special situations, _Tempo Clues_ have enough value to justify giving them:
   1. When everyone knows it gets two or more clued cards to play (in total across all hands).
-  1. When the clued card can't be _Prompted_ because another card is blocking it (such as when g2 and g3 are "out of order" and both already clued with green).
+  1. When the clued card cannot be _Prompted_ (because there is another unplayable clued card in the hand that would "block" the _Prompt_).
   1. When playing the clued card would "unlock" someone's hand. (For level 9 players, see the section on [_Locked Hands_](level-9.mdx#the-locked-hand-save-lhs).)
 - If a _Tempo Clue_ is given in any of these situations, it is considered to be "valuable".
 - _Valuable Tempo Clues_ can be given at any time. They don't have any special rules associated with them and they are treated in exactly the same way a "normal" _Play Clue_ is.


### PR DESCRIPTION
With the old wording, I interpreted "out of order" to only apply to cards in the same suit, where one of them _must_ play before the other _can_ play. With multiple unknown 2s, there's no order in which the cards are required to play, but the left one can still block a prompt on the right one, preventing a playable 3 from being clued.