### PR TITLE
Zoom on mermaid charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react": "18.3.1",
         "react-circular-progressbar": "^2.1.0",
         "react-dom": "18.3.1",
+        "react-zoom-pan-pinch": "^3.7.0",
         "yaml": "^2.7.0",
         "zod": "^3.24.1"
       },
@@ -21226,6 +21227,20 @@
       },
       "peerDependencies": {
         "react": ">=15"
+      }
+    },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.7.0.tgz",
+      "integrity": "sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/read": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react": "18.3.1",
     "react-circular-progressbar": "^2.1.0",
     "react-dom": "18.3.1",
+    "react-zoom-pan-pinch": "^3.7.0",
     "yaml": "^2.7.0",
     "zod": "^3.24.1"
   },

--- a/src/theme/Mermaid/index.tsx
+++ b/src/theme/Mermaid/index.tsx
@@ -1,0 +1,14 @@
+import React, {type ReactNode} from 'react';
+import Mermaid from '@theme-original/Mermaid';
+import type MermaidType from '@theme/Mermaid';
+import type {WrapperProps} from '@docusaurus/types';
+
+type Props = WrapperProps<typeof MermaidType>;
+
+export default function MermaidWrapper(props: Props): ReactNode {
+  return (
+    <>
+      <Mermaid {...props} />
+    </>
+  );
+}

--- a/src/theme/Mermaid/index.tsx
+++ b/src/theme/Mermaid/index.tsx
@@ -58,6 +58,7 @@ export default function MermaidWrapper(props: Props): ReactNode {
             wrapperStyle={{
               width: "100%",
               aspectRatio: chartSize.width / chartSize.height,
+              maxHeight: "75vh",
             }}
           >
             <div ref={chart}>

--- a/src/theme/Mermaid/index.tsx
+++ b/src/theme/Mermaid/index.tsx
@@ -1,14 +1,71 @@
-import React, {type ReactNode} from 'react';
-import Mermaid from '@theme-original/Mermaid';
-import type MermaidType from '@theme/Mermaid';
-import type {WrapperProps} from '@docusaurus/types';
+import type { WrapperProps } from "@docusaurus/types";
+import Mermaid from "@theme-original/Mermaid";
+import type MermaidType from "@theme/Mermaid";
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+import {
+  ReactZoomPanPinchContentRef,
+  TransformComponent,
+  TransformWrapper,
+} from "react-zoom-pan-pinch";
 
 type Props = WrapperProps<typeof MermaidType>;
 
+type Size = {
+  width: number;
+  height: number;
+};
+
+function useSize(ref: React.RefObject<HTMLElement>): Size {
+  const [size, setSize] = useState<Size>({ width: 1, height: 1 });
+  useLayoutEffect(() => {
+    if (!ref.current) return;
+    let r = ref.current!;
+    let observer = new ResizeObserver(() => {
+      let rect = r.getBoundingClientRect();
+      setSize(rect);
+    });
+    observer.observe(r);
+    return () => observer.disconnect();
+  }, [ref]);
+  return size;
+}
+
 export default function MermaidWrapper(props: Props): ReactNode {
+  const container = useRef<HTMLDivElement>(null);
+  const containerSize = useSize(container);
+
+  const chart = useRef<HTMLDivElement>(null);
+  const chartSize = useSize(chart);
+
+  const transformWrapper = useRef<ReactZoomPanPinchContentRef>(null);
+
+  useEffect(() => {
+    transformWrapper.current!.zoomToElement(chart.current!, undefined, 0);
+  }, [containerSize, chartSize]);
+
   return (
     <>
-      <Mermaid {...props} />
+      <div ref={container}>
+        <TransformWrapper ref={transformWrapper}>
+          <TransformComponent
+            wrapperStyle={{
+              width: "100%",
+              aspectRatio: chartSize.width / chartSize.height,
+            }}
+          >
+            <div ref={chart}>
+              <Mermaid {...props} />
+            </div>
+          </TransformComponent>
+        </TransformWrapper>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
@HungryBradbury and @Zamiell were talking on [discord](https://discord.com/channels/140016142600241152/1317134525024964650) about how to zoom into the new mermaid flowcharts and that it felt janky to zoom the whole page to 200% to look at what is written on them.

This PR adds a wrapper to the mermaid component (generated automatically from markdown) that allows zooming into the charts. it uses [react-zoom-pan-pinch](https://github.com/BetterTyped/react-zoom-pan-pinch) to handle it.

I wanted to keep the same starting state for all of the charts, so I had to add some calculations for the size and starting zoom on the new wrapper.