### PR TITLE
Explicitly stating that TC to a 5 is non-valuable

### DIFF
--- a/docs/level-6.mdx
+++ b/docs/level-6.mdx
@@ -23,6 +23,7 @@ import DiscardModulation from "./level-6/discard-modulation.yml";
   1. When the clued card is not a 5 and cannot be _Prompted_ (because there is another unplayable clued card in the hand that would misplay if the _Prompt_ was attempted).
   1. When playing the clued card would "unlock" someone's hand. (For level 9 players, see the section on [_Locked Hands_](level-9.mdx#the-locked-hand-save-lhs).)
 - If a _Tempo Clue_ is given in any of these situations, it is considered to be "valuable".
+  - A tempo clue to a 5 in any position is non-valuable.
 - _Valuable Tempo Clues_ can be given at any time. They don't have any special rules associated with them and they are treated in exactly the same way a "normal" _Play Clue_ is.
 - When determining if a _Tempo Clue_ is _Valuable_, it should only be evaluated on the turn immediately after the clue is given. (This helps keeps things simple and prevents desynchronization.)
 

--- a/docs/level-6.mdx
+++ b/docs/level-6.mdx
@@ -23,9 +23,9 @@ import DiscardModulation from "./level-6/discard-modulation.yml";
   1. When the clued card is not a 5 and cannot be _Prompted_ (because there is another unplayable clued card in the hand that would misplay if the _Prompt_ was attempted).
   1. When playing the clued card would "unlock" someone's hand. (For level 9 players, see the section on [_Locked Hands_](level-9.mdx#the-locked-hand-save-lhs).)
 - If a _Tempo Clue_ is given in any of these situations, it is considered to be "valuable".
-  - A tempo clue to a 5 in any position is non-valuable.
 - _Valuable Tempo Clues_ can be given at any time. They don't have any special rules associated with them and they are treated in exactly the same way a "normal" _Play Clue_ is.
 - When determining if a _Tempo Clue_ is _Valuable_, it should only be evaluated on the turn immediately after the clue is given. (This helps keeps things simple and prevents desynchronization.)
+- Note that even though 5's cannot be _Prompted_ (since there is no 6th rank), _Tempo Clues_ to 5s are not considered valuable.
 
 ### The Tempo Clue Stall (A Non-Valuable Tempo Clue)
 


### PR DESCRIPTION
I've always had a problem with 'when the card is not a 5' in the second bullet point of conditions of a valuable tempo clue. Because there are two ways to interpret this. 
1) The intended way, that any tc to a 5 in any position is non-valuable.
2) That because this condition is merged with the 'unpromptable' condition, since any 5 is unpromptable, any tc to a 5 in any position is always valuable (also because playing a 5 always returns the clue that was used up in play-cluing it.)

So I want the doc to explicitly state this somewhere.