### PR TITLE
Reword 5cm "one away from chop"

### DIFF
--- a/docs/level-4.mdx
+++ b/docs/level-4.mdx
@@ -69,7 +69,7 @@ import ChopMovePrompt from "./level-4/chop-move-prompt.yml";
 - Normally, we are only allowed to save 5's that are on chop, with the special move called the _5 Save_.
 - Additionally, 5's can also be saved indirectly with the special move called the _5 Stall_, which can happen in the _Early Game_ and in other "stalling" situations.
 - So, if a number 5 clue is performed on a 5 that is not on chop, and it is **not** a stalling situation, then it will normally look like a _Play Clue_ on that 5.
-- However, if a 5 is exactly **one-away** from chop, then we agree that it has a special meaning, and that the clue is **not** a _Play Clue_ at all.
+- However, if a 5 is the **rightmost, non-chop, unclued card**, then we agree that it has a special meaning, and that the clue is **not** a _Play Clue_ at all.
 - Instead, we agree that the clue is a _5's Chop Move_, and the player should _Chop Move_ the card to the right of the 5 (similarly to the _Trash Chop Move_).
 - For example, in a 3-player game:
   - All the 1's are played on the stacks.

--- a/docs/level-4.mdx
+++ b/docs/level-4.mdx
@@ -69,8 +69,9 @@ import ChopMovePrompt from "./level-4/chop-move-prompt.yml";
 - Normally, we are only allowed to save 5's that are on chop, with the special move called the _5 Save_.
 - Additionally, 5's can also be saved indirectly with the special move called the _5 Stall_, which can happen in the _Early Game_ and in other "stalling" situations.
 - So, if a number 5 clue is performed on a 5 that is not on chop, and it is **not** a stalling situation, then it will normally look like a _Play Clue_ on that 5.
-- However, if a 5 is the **rightmost, non-chop, unclued card**, then we agree that it has a special meaning, and that the clue is **not** a _Play Clue_ at all.
-- Instead, we agree that the clue is a _5's Chop Move_, and the player should _Chop Move_ the card to the right of the 5 (similarly to the _Trash Chop Move_).
+- However, if a 5 is **one-away** from chop, then we agree that it has a special meaning, and that the clue is **not** a _Play Clue_ at all.
+  - Specifically, "one-away from chop" means that if the player discarded their chop twice, then they would discard the 5.
+- We agree that the special meaning is a _5's Chop Move_: the player should _Chop Move_ the card to the right of the 5 (similarly to the _Trash Chop Move_).
 - For example, in a 3-player game:
   - All the 1's are played on the stacks.
   - Bob has a completely unclued hand.


### PR DESCRIPTION
Per discussion at https://discord.com/channels/140016142600241152/1330511255445962812, some beginners were misinterpreting "one away from chop", thinking it meant "the card directly left of chop (clued or unclued)". I don't love this new wording, but I think it's more clear.