### PR TITLE
Make zoom step on flowcharts configurable

### DIFF
--- a/src/theme/Mermaid/index.tsx
+++ b/src/theme/Mermaid/index.tsx
@@ -10,7 +10,7 @@ type Props = WrapperProps<typeof MermaidType>;
 
 const CONFIG = {
   scroll_step: 0.5,
-};
+} as const;
 
 interface Size {
   width: number;

--- a/src/theme/Mermaid/index.tsx
+++ b/src/theme/Mermaid/index.tsx
@@ -8,6 +8,10 @@ import { TransformComponent, TransformWrapper } from "react-zoom-pan-pinch";
 
 type Props = WrapperProps<typeof MermaidType>;
 
+const CONFIG = {
+  scroll_step: 0.5,
+};
+
 interface Size {
   width: number;
   height: number;
@@ -50,7 +54,13 @@ export default function MermaidWrapper(props: Props): ReactNode {
   return (
     <>
       <div ref={container}>
-        <TransformWrapper ref={transformWrapper}>
+        <TransformWrapper
+          ref={transformWrapper}
+          wheel={{
+            step: CONFIG.scroll_step,
+            smoothStep: CONFIG.scroll_step / 200,
+          }}
+        >
           <TransformComponent
             wrapperStyle={{
               width: "100%",


### PR DESCRIPTION
the default scroll_step was 0.2. I just set it to 0.5, but we can quickly change it if needed.