### PR TITLE
Updated 5’s Chop Move convention

### DIFF
--- a/docs/level-4.mdx
+++ b/docs/level-4.mdx
@@ -92,7 +92,6 @@ import ChopMovePrompt from "./level-4/chop-move-prompt.yml";
 - Note that the _5's Chop Move_ is different from the _Trash Chop Move_ in that you can only chop move **one** card with it. Thus, if you clue a 5 and it is **two** (or more) slots away from the chop, then it is a _Play Clue_ on the 5.
   - When counting how far away from chop a card is, you should only look at **unclued** cards.
 - Remember that _5 Stalls_ take precedence over _5's Chop Moves_. Thus, if a number 5 clue **could** just be a _5 Stall_ (e.g. it is the _Early Game_), then it does not _Chop Move_ anything.
-  - Technically, one could try to analyze whether a clue is a _5 Stall_ or _5's Chop Move_ by looking at whether the clue-giver had a different clue to give, since _5 Stalls_ are only permitted if all "normal" _Play Clues_ and _Save Clues_ have been extinguished. However, this analysis relies on asymmetric information, and can be confusing even for experienced players. So, this move is not introduced until [level 19](level-19.mdx#special-moves).
 - For level 19 players, see the _[Early 5's Chop Move](level-19.mdx#the-early-5s-chop-move)_.
 - For level 21 players, there are [additional rules](level-21.mdx#interaction-between-the-chop-move-ignition-and-5-rank-clues) relating to the _5's Chop Move_.
 


### PR DESCRIPTION
With the change to 5 Stalls, players may now use them even when other clues are available all the way up to Level 9. Thus the block of text talking about analyzing if the clue-giver had another viable clue to figure out if a the 5 clue is a Stall or a Chop Move is relying on out-of-level rules about 5 Stalls. The 5’s Early Chop Move convention in Level 19 reintroduces the idea from scratch, so nothing is lost from deleting this paragraph.