### PR TITLE
Level 1 - 2 Save - fixed typo.

### DIFF
--- a/docs/level-1.mdx
+++ b/docs/level-1.mdx
@@ -110,7 +110,7 @@ D3N --> D3NL;
 ### The 2 Save
 
 - A _2 Save_ is when someone uses a number 2 clue to touch a previously-unclued 2 on someone's chop. (Everyone agrees that this is just a _Save Clue_ instead of a _Play Clue_.)
-- By definition, you can only perform a _2 Save_ with a number clue. (If a color clue was used to touch an unclued 5, then it would be a _Play Clue_ instead.)
+- By definition, you can only perform a _2 Save_ with a number clue. (If a color clue was used to touch an unclued 2, then it would be a _Play Clue_ instead.)
   - The exception is if the other copy of the 2 is in the discard pile. Then, touching the card with a color clue would be a _Critical Save_. But that would not classified as a _2 Save_.
 
 #### The Visible Rule


### PR DESCRIPTION
This pull request fixes a slight typo in Level 2, in the paragraph related to the _2 Save_ special move.

```patch
  By definition, you can only perform a _2 Save_ with a number clue. 
- (If a color clue was used to touch an unclued 5, then it would be a _Play Clue_ instead.)
+ (If a color clue was used to touch an unclued 2, then it would be a _Play Clue_ instead.)

```