### PR TITLE
Disable hotkey whenever an `<input>` is focused

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -18,8 +18,8 @@ function main() {
       return;
     }
 
-    // Do not do anything if we have the search box focused.
-    if (isSearchBarFocused()) {
+    // Do not do anything if we are typing in an input field.
+    if (isInputFocused()) {
       return;
     }
 
@@ -31,7 +31,8 @@ function main() {
 }
 
 /** @returns {boolean} */
-function isSearchBarFocused() {
+function isInputFocused() {
+  // Checking for input elements is more robust than specifically matching the standard search bar.
   return document.activeElement instanceof HTMLInputElement;
 }
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -32,14 +32,7 @@ function main() {
 
 /** @returns {boolean} */
 function isSearchBarFocused() {
-  // eslint-disable-next-line unicorn/prefer-spread
-  const searchInputElements = Array.from(
-    document.querySelectorAll(".DocSearch-Input"),
-  );
-  return (
-    document.activeElement !== null &&
-    searchInputElements.includes(document.activeElement)
-  );
+  return document.activeElement instanceof HTMLInputElement;
 }
 
 function navigateBackwards() {


### PR DESCRIPTION
The website contains hotkeys such as `l` for jumping across levels. Currently, they are only disabled when the search panel pops up. There is also a `/search` page, and the user can enter that page from the search panel when there are too many search results (for example when the search string is a single letter). Under `/search`, the user can further modify the search string in a larger `<input>`. However, hotkeys are not disabled for this page, which makes typing `l` there quite problematic.

This pull request instead disables hotkeys whenever an `<input>` is focused, since all current hotkeys contribute to text typing. There does not seem to be `<textarea>`'s or other editable elements, so this should suffice.