### PR TITLE
level 4: chop move focus exception

### DIFF
--- a/docs/level-4/chop-move-new-exception.yml
+++ b/docs/level-4/chop-move-new-exception.yml
@@ -42,8 +42,10 @@ players:
         above: Chop
       - type: m
         clue: b
+        retouched: true
       - type: m
         clue: b
+        retouched: true
       - type: b
         clue: b
         below: Focus


### PR DESCRIPTION
This pull request updates the game state diagram for the Level 4 section titled **[Chop Moves & New Clues](https://hanabi.github.io/level-4#chop-moves--new-clues)** related to clarifying the focus of a clue that touches a _Chop Moved_ card for the first time.

![image](https://github.com/user-attachments/assets/a06d938a-e38a-4610-8803-fa089300ee90)

It specifically highlights that the two previously unknown "red" cards are retouched and, thus, the clue only touches old cards and the _Chop Moved_ card for the first time.