### PR TITLE
Fix image-text mismatch in level 14

### DIFF
--- a/docs/level-14.mdx
+++ b/docs/level-14.mdx
@@ -48,8 +48,8 @@ import TrashPush from "./level-14/trash-push.yml";
   - For level 24 players, an [extra thing happens](level-24.mdx#trash-finesses-and-trash-bluffs-are-always-unnecessary).
 
 - For example, in a 4-player game:
-  - All the 1's are played on the stacks except for red 1 and green 1.
-  - Alice clues number 1 to Donald, which touches a blue 1. To Donald, this will look like it is a red 1 or green 1.
+  - All the 1's are played on the stacks except for red 1 and yellow 1.
+  - Alice clues number 1 to Donald, which touches a blue 1. To Donald, this will look like it is a red 1 or yellow 1.
   - Bob sees that Cathy has a red 1 on her _Finesse Position_ and, thus, discards.
   - Cathy blind-plays her _Finesse Position_ card and it is red 1.
   - Donald discards his known-trash 1. He also marks his slot 3 and slot 4 cards as being _Chop Moved_.
@@ -58,7 +58,7 @@ import TrashPush from "./level-14/trash-push.yml";
 
 - In the case where multiple cards are clued as part of a _Trash Finesse_, **all** of the touched cards are considered to be trash. (This is same thing that happens in a _Trash Bluff_.)
 - _Double Trash Finesses_ are explicitly disallowed. Thus, it is possible to perform a _Trash Finesse_ in a situation like this:
-  - Green 1 and purple 1 are played on the stacks.
+  - All the 1's are played on the stacks except for red 1 and blue 1.
   - Alice clues number 1 to Donald, which touches two green 1's on slot 1 and 2. To Donald, this will look like it is both the red 1 and the blue 1.
   - Like in the previous example, Bob sees that Cathy has a red 1 on her _Finesse Position_.
   - At first glance, Bob might think that Alice is promising both red 1 and blue 1, which would mean that he would need to blind-play the blue 1.
@@ -113,7 +113,7 @@ import TrashPush from "./level-14/trash-push.yml";
 - For example, in a 3-player game:
   - All of the 1's are played on the stacks **except** for the red 1.
   - Cathy has no clued cards in her hand.
-  - Alice clues Cathy number 1, which only touches her newest (slot 1) card. This card is a blue 1, but Cathy will assume that it is a red 1.
+  - Alice clues Cathy number 1, which only touches her slot 2 card. This card is a blue 1, but Cathy will assume that it is a red 1.
   - Bob blind-plays his _Finesse Position_ card, and it is a playable blue 2.
   - Cathy now knows that her 1 must not be red 1, or else Bob would not have blind-played anything. The 1 must be some other trash card.
   - Additionally, Cathy marks her slot 3, slot 4, and slot 5 cards as being _Chop Moved_.
@@ -121,7 +121,7 @@ import TrashPush from "./level-14/trash-push.yml";
 <TrashBluff />
 
 - Just like normal _Bluffs_, _Trash Bluffs_ can only be done while in _Bluff Seat_.
-- Normal _Bluffs_ take precedence over _Trash Bluffs_. This means that players can **only** use cards to _Trash Bluff_ with if they will be proved to be trash by a blind-play.
+- Normal _Bluffs_ take precedence over _Trash Bluffs_. This means that players can **only** perform _Trash Bluff_ with cards that will be proved to be trash by a blind-play.
   - For example, if not all of the 1's have been played on the stacks, then you can use a number 1 clue to initiate a _Trash Bluff_, because a blind-play will prove that the clued 1 is not a good 1.
   - For example, if the red stack is played up to the red 3, then you **cannot** use a red clue to initiate a _Trash Bluff_, because a blind-play will make the clued card look like the red 5.
   - For example, if the red stack is played up to the red 4, then you can use a red clue to initiate a _Trash Bluff_, because a blind-play will prove that the clued card is not a red 5.


### PR DESCRIPTION
I notice that level 14 contains a few mismatch between text and image in examples. I choose to change everything in the text to match the images.

Also, I feel there's a grammatical mistake on line 124 (an extra "with"), so I modify the sentence to make it more fluent.