### PR TITLE
Lvl 17 YML fixing Retouched status

### DIFF
--- a/docs/level-17/time-travel-chop-move-blind-play-form.yml
+++ b/docs/level-17/time-travel-chop-move-blind-play-form.yml
@@ -19,6 +19,7 @@ players:
         below: plays
       - type: r3
         clue: 3
+        retouched: true
       - type: x
       - type: x
       - type: x


### PR DESCRIPTION
In TTCM Blind-Play Form example, the clue to r3 is a reclue, but the YML diagram shows it as a new clue.