### PR TITLE
Level 4 Challenge Question: Fresh 1's and OCM

### DIFF
--- a/docs/challenge-questions/level-4-question-1-part-2.yml
+++ b/docs/challenge-questions/level-4-question-1-part-2.yml
@@ -41,14 +41,14 @@ players:
   - name: Bob
     cards:
       - type: x
-      - type: 1
-        clue: 1
+      - type: x
+        middleNote: (1)
         below:
           text:
             - Fresh
           color: Green
-      - type: 1
-        clue: 1
+      - type: x
+        middleNote: (1)
         below:
           text:
             - Starting

--- a/docs/challenge-questions/level-4-question-1-part-2.yml
+++ b/docs/challenge-questions/level-4-question-1-part-2.yml
@@ -1,0 +1,58 @@
+players:
+  - name: Alice
+    cards:
+      - type: x
+        middleNote: (1)
+        below:
+          text:
+            - Starting
+            - Hand
+          color: Gray
+      - type: b
+        middleNote: (3)
+        clue: b
+      - type: x
+      - type: b
+        middleNote: (4)
+        clue: b
+      - type: x
+  - text: "After playing blue 3:"
+  - name: Alice
+    cards:
+      - type: x
+        middleNote: (1)
+        below:
+          text:
+            - Fresh
+          color: Green
+      - type: x
+        middleNote: (1)
+        below:
+          text:
+            - Starting
+            - Hand
+          color: Gray
+      - type: x
+      - type: b
+        middleNote: (4)
+        clue: b
+      - type: x
+  - text: "After playing blue 4:"
+  - name: Alice
+    cards:
+      - type: x
+      - type: 1
+        clue: 1
+        below:
+          text:
+            - Fresh
+          color: Green
+      - type: 1
+        clue: 1
+        below:
+          text:
+            - Starting
+            - Hand
+          color: Gray
+      - type: x
+      - type: x

--- a/docs/challenge-questions/level-4-question-1-part-2.yml
+++ b/docs/challenge-questions/level-4-question-1-part-2.yml
@@ -1,5 +1,5 @@
 players:
-  - name: Alice
+  - name: Bob
     cards:
       - type: x
         middleNote: (1)
@@ -17,7 +17,7 @@ players:
         clue: b
       - type: x
   - text: "After playing blue 3:"
-  - name: Alice
+  - name: Bob
     cards:
       - type: x
         middleNote: (1)
@@ -38,7 +38,7 @@ players:
         clue: b
       - type: x
   - text: "After playing blue 4:"
-  - name: Alice
+  - name: Bob
     cards:
       - type: x
       - type: 1

--- a/docs/challenge-questions/level-4-question-1-part-3.yml
+++ b/docs/challenge-questions/level-4-question-1-part-3.yml
@@ -16,7 +16,6 @@ players:
       - type: x
       - type: x
       - type: 1
-        clue: 1
         below:
           text:
             - Fresh

--- a/docs/challenge-questions/level-4-question-1-part-3.yml
+++ b/docs/challenge-questions/level-4-question-1-part-3.yml
@@ -5,6 +5,13 @@ stacks:
   - b: 5
   - p: 0
 players:
+  - clueGiver: true
+    cards:
+      - type: x
+      - type: x
+      - type: x
+      - type: x
+      - type: x
   - cards:
       - type: x
       - type: x
@@ -26,10 +33,3 @@ players:
             - Move
       - type: 2
       - type: 2
-  - clueGiver: true
-    cards:
-      - type: x
-      - type: x
-      - type: x
-      - type: x
-      - type: x

--- a/docs/challenge-questions/level-4-question-1-part-3.yml
+++ b/docs/challenge-questions/level-4-question-1-part-3.yml
@@ -1,0 +1,35 @@
+stacks:
+  - r: 1
+  - y: 0
+  - g: 1
+  - b: 5
+  - p: 0
+players:
+  - cards:
+      - type: x
+      - type: x
+      - type: 1
+        clue: 1
+        below:
+          text:
+            - Fresh
+          color: Green
+      - type: x
+      - type: x
+  - cards:
+      - type: x
+      - type: x
+      - type: x
+        above:
+          text:
+            - Chop
+            - Move
+      - type: 2
+      - type: 2
+  - clueGiver: true
+    cards:
+      - type: x
+      - type: x
+      - type: x
+      - type: x
+      - type: x

--- a/docs/challenge-questions/level-4-question-1.yml
+++ b/docs/challenge-questions/level-4-question-1.yml
@@ -1,0 +1,28 @@
+stacks:
+  - r: 1
+  - y: 0
+  - g: 0
+  - b: 5
+  - p: 0
+players:
+  - cards:
+      - type: x
+      - type: 1
+        clue: 1
+      - type: 1
+        clue: 1
+      - type: x
+      - type: x
+  - cards:
+      - type: x
+      - type: x
+      - type: x
+      - type: 2
+      - type: 2
+  - clueGiver: true
+    cards:
+      - type: x
+      - type: x
+      - type: x
+      - type: x
+      - type: x

--- a/docs/challenge-questions/level-4-question-1.yml
+++ b/docs/challenge-questions/level-4-question-1.yml
@@ -5,20 +5,6 @@ stacks:
   - b: 5
   - p: 0
 players:
-  - cards:
-      - type: x
-      - type: 1
-        clue: 1
-      - type: 1
-        clue: 1
-      - type: x
-      - type: x
-  - cards:
-      - type: x
-      - type: x
-      - type: x
-      - type: 2
-      - type: 2
   - clueGiver: true
     cards:
       - type: x
@@ -26,3 +12,17 @@ players:
       - type: x
       - type: x
       - type: x
+  - cards:
+      - type: x
+      - type: 1
+        clue: 1
+      - type: 1
+        clue: 1
+      - type: x
+      - type: x
+  - cards:
+      - type: x
+      - type: x
+      - type: x
+      - type: 2
+      - type: 2

--- a/docs/challenge-questions/level-4.mdx
+++ b/docs/challenge-questions/level-4.mdx
@@ -25,9 +25,9 @@ These questions are for [level 4](../level-4.mdx) strategies.
 - Red 1 and blue 5 are played on the stacks.
 - Previously, Bob played blue 3 from slot 2 and blue 4 from slot 4.
 - Cathy has two unknown 2's saved on chop.
-- Alice clues 1 to Bob which touches the cards in slot 2 and 3.
+- Alice clues number 1 to Bob which touches the cards in slot 2 and 3.
 - Bob plays his slot 3 card. It is a green 1 and successfully plays.
-- What action will Cathy take on her turn?
+- What slot will Cathy discard next?
 
 <Question1 />
 
@@ -40,12 +40,9 @@ These questions are for [level 4](../level-4.mdx) strategies.
 
 <Solution1Part1 />
 
-- Everyone agrees that unknown 1's are supposed to be played in a particular order.
-- Even though Bob played his rightmost unknown 1 first, this is not the expected play order as "fresh" 1's take precedence.
-- Therefore, he must have meant to send a signal.
-- Cathy recognizes that Bob performed an _Order Chop Move_.
-- Thus Cathy should _Chop Move_ her slot 3 card.
-- Cathy writes "cm" on her slot 3 card and proceeds to give a clue or discard her slot 2 card.
+- As established in level 3, [unknown 1's are supposed to be played in a particular order](../level-3.mdx#playing-multiple-1s). Specifically, [fresh 1's are supposed to have precedence](../level-3.mdx#part-2---the-fresh-1s-rule).
+- This means that Bob was expected to play his slot 2 card instead of his slot 3 card.
+- Thus, Cathy knows that Bob intended for an _Order Chop Move_. Cathy _Chop Moves_ her slot 3 card. Her new chop is slot 2, so that would be the slot that Cathy would discard next.
 
 <Solution1Part2 />
 

--- a/docs/challenge-questions/level-4.mdx
+++ b/docs/challenge-questions/level-4.mdx
@@ -3,7 +3,7 @@ title: Level 4 Challenge Questions
 ---
 
 import Question1 from "./level-4-question-1.yml";
-import Solution1 from "./level-4-question-1-part-2.yml";
+import Solution1Part1 from "./level-4-question-1-part-2.yml";
 import Solution1Part2 from "./level-4-question-1-part-3.yml";
 
 import Tabs from "@theme/Tabs";
@@ -25,7 +25,7 @@ These questions are for [level 4](../level-4.mdx) strategies.
 - Alice played the blue 3 card from slot 2 and the blue 4 card from slot 4 thus far.
 - Bob has two unknown 2's saved on chop.
 - Cathy clues 1 to Alice which touches the cards in slot 2 and 3.
-- Alice plays here slot 3 card and initiates the green stack.
+- Alice plays her slot 3 card and initiates the green stack.
 - What actions will Bob take on his turn?
 
 <Question1 />
@@ -33,11 +33,11 @@ These questions are for [level 4](../level-4.mdx) strategies.
 </TabItem>
 <TabItem value="solution1">
 
-- As Alice played two cards from slots 2 and 4 respectively, her starting hand slot 1 card slid over by two position.
-- As a result, her now slot 3 card was in her starting hand, while her slot 2 card must have been drawn after Alice played blue 3.
+- As Alice played two cards from slots 2 and 4 respectively, her starting hand slot 1 card slid over by two positions.
+- As a result, her slot 3 card was initially in her starting hand, while her slot 2 card must have been drawn after Alice played blue 3.
 - Thus, her slot 2 card is a "fresh" 1, whereas her slot 3 card is a 1 from the starting hand.
 
-<Solution1 />
+<Solution1Part1 />
 
 - Everyone agrees that unknown 1's are supposed to be played in a particular order.
 - Even though Alice played her rightmost unknown 1 first, this is not the expected play order as "fresh" 1's take precedence.

--- a/docs/challenge-questions/level-4.mdx
+++ b/docs/challenge-questions/level-4.mdx
@@ -22,8 +22,8 @@ These questions are for [level 4](../level-4.mdx) strategies.
 <TabItem value="question1">
 
 - It is the _Early Game_.
-- The red 1 and blue 5 is played on the stacks.
-- Bob played the blue 3 card from slot 2 and the blue 4 card from slot 4 thus far.
+- Red 1 and blue 5 are played on the stacks.
+- Previously, Bob played blue 3 from slot 2 and blue 4 from slot 4.
 - Cathy has two unknown 2's saved on chop.
 - Alice clues 1 to Bob which touches the cards in slot 2 and 3.
 - Bob plays his slot 3 card and initiates the green stack.

--- a/docs/challenge-questions/level-4.mdx
+++ b/docs/challenge-questions/level-4.mdx
@@ -26,17 +26,17 @@ These questions are for [level 4](../level-4.mdx) strategies.
 - Previously, Bob played blue 3 from slot 2 and blue 4 from slot 4.
 - Cathy has two unknown 2's saved on chop.
 - Alice clues 1 to Bob which touches the cards in slot 2 and 3.
-- Bob plays his slot 3 card and initiates the green stack.
-- What actions will Cathy take on her turn?
+- Bob plays his slot 3 card. It is a green 1 and successfully plays.
+- What action will Cathy take on her turn?
 
 <Question1 />
 
 </TabItem>
 <TabItem value="solution1">
 
-- As Bob played two cards from slots 2 and 4 respectively, his starting hand slot 1 card slid over by two positions.
-- As a result, his slot 3 card was initially in his starting hand, while his slot 2 card must have been drawn after Bob played blue 3.
-- Thus, his slot 2 card is a "fresh" 1, whereas his slot 3 card is a 1 from the starting hand.
+- Since Bob previously played a card from slot 2 and 4, he has drawn two cards.
+- As a result, his slot 3 card must have been in his starting hand, while his slot 2 card must have been drawn after playing the blue 3.
+- Thus, his slot 2 card is a "fresh" one and his slot 3 card is a "normal" one from the starting hand.
 
 <Solution1Part1 />
 

--- a/docs/challenge-questions/level-4.mdx
+++ b/docs/challenge-questions/level-4.mdx
@@ -23,29 +23,29 @@ These questions are for [level 4](../level-4.mdx) strategies.
 
 - It is the _Early Game_.
 - The red 1 and blue 5 is played on the stacks.
-- Alice played the blue 3 card from slot 2 and the blue 4 card from slot 4 thus far.
-- Bob has two unknown 2's saved on chop.
-- Cathy clues 1 to Alice which touches the cards in slot 2 and 3.
-- Alice plays her slot 3 card and initiates the green stack.
-- What actions will Bob take on his turn?
+- Bob played the blue 3 card from slot 2 and the blue 4 card from slot 4 thus far.
+- Cathy has two unknown 2's saved on chop.
+- Alice clues 1 to Bob which touches the cards in slot 2 and 3.
+- Bob plays his slot 3 card and initiates the green stack.
+- What actions will Cathy take on her turn?
 
 <Question1 />
 
 </TabItem>
 <TabItem value="solution1">
 
-- As Alice played two cards from slots 2 and 4 respectively, her starting hand slot 1 card slid over by two positions.
-- As a result, her slot 3 card was initially in her starting hand, while her slot 2 card must have been drawn after Alice played blue 3.
-- Thus, her slot 2 card is a "fresh" 1, whereas her slot 3 card is a 1 from the starting hand.
+- As Bob played two cards from slots 2 and 4 respectively, his starting hand slot 1 card slid over by two positions.
+- As a result, his slot 3 card was initially in his starting hand, while his slot 2 card must have been drawn after Bob played blue 3.
+- Thus, his slot 2 card is a "fresh" 1, whereas his slot 3 card is a 1 from the starting hand.
 
 <Solution1Part1 />
 
 - Everyone agrees that unknown 1's are supposed to be played in a particular order.
-- Even though Alice played her rightmost unknown 1 first, this is not the expected play order as "fresh" 1's take precedence.
-- Therefore, she must have meant to send a signal.
-- Bob recognizes that Alice performed an _Order Chop Move_.
-- Thus Bob should _Chop Move_ his slot 3 card.
-- Bob writes "cm" on his slot 3 card and proceeds to give a clue or discard his slot 2 card.
+- Even though Bob played his rightmost unknown 1 first, this is not the expected play order as "fresh" 1's take precedence.
+- Therefore, he must have meant to send a signal.
+- Cathy recognizes that Bob performed an _Order Chop Move_.
+- Thus Cathy should _Chop Move_ her slot 3 card.
+- Cathy writes "cm" on her slot 3 card and proceeds to give a clue or discard her slot 2 card.
 
 <Solution1Part2 />
 

--- a/docs/challenge-questions/level-4.mdx
+++ b/docs/challenge-questions/level-4.mdx
@@ -21,7 +21,8 @@ These questions are for [level 4](../level-4.mdx) strategies.
   ]}>
 <TabItem value="question1">
 
-- It is still _Early Game_. and the red 1 is played on the stacks while the blue stack has been completed.
+- It is the _Early Game_.
+- The red 1 and blue 5 is played on the stacks.
 - Alice played the blue 3 card from slot 2 and the blue 4 card from slot 4 thus far.
 - Bob has two unknown 2's saved on chop.
 - Cathy clues 1 to Alice which touches the cards in slot 2 and 3.

--- a/docs/challenge-questions/level-4.mdx
+++ b/docs/challenge-questions/level-4.mdx
@@ -1,0 +1,52 @@
+---
+title: Level 4 Challenge Questions
+---
+
+import Question1 from "./level-4-question-1.yml";
+import Solution1 from "./level-4-question-1-part-2.yml";
+import Solution1Part2 from "./level-4-question-1-part-3.yml";
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+These questions are for [level 4](../level-4.mdx) strategies.
+
+## Question 1
+
+<Tabs
+  defaultValue="question1"
+  values={[
+    {label: 'Question', value: 'question1'},
+    {label: 'Solution', value: 'solution1'},
+  ]}>
+<TabItem value="question1">
+
+- It is still _Early Game_. and the red 1 is played on the stacks while the blue stack has been completed.
+- Alice played the blue 3 card from slot 2 and the blue 4 card from slot 4 thus far.
+- Bob has two unknown 2's saved on chop.
+- Cathy clues 1 to Alice which touches the cards in slot 2 and 3.
+- Alice plays here slot 3 card and initiates the green stack.
+- What actions will Bob take on his turn?
+
+<Question1 />
+
+</TabItem>
+<TabItem value="solution1">
+
+- As Alice played two cards from slots 2 and 4 respectively, her starting hand slot 1 card slid over by two position.
+- As a result, her now slot 3 card was in her starting hand, while her slot 2 card must have been drawn after Alice played blue 3.
+- Thus, her slot 2 card is a "fresh" 1, whereas her slot 3 card is a 1 from the starting hand.
+
+<Solution1 />
+
+- Everyone agrees that unknown 1's are supposed to be played in a particular order.
+- Even though Alice played her rightmost unknown 1 first, this is not the expected play order as "fresh" 1's take precedence.
+- Therefore, she must have meant to send a signal.
+- Bob recognizes that Alice performed an _Order Chop Move_.
+- Thus Bob should _Chop Move_ his slot 3 card.
+- Bob writes "cm" on his slot 3 card and proceeds to give a clue or discard his slot 2 card.
+
+<Solution1Part2 />
+
+</TabItem>
+</Tabs>

--- a/docs/level-4.mdx
+++ b/docs/level-4.mdx
@@ -185,3 +185,7 @@ import ChopMovePrompt from "./level-4/chop-move-prompt.yml";
 - Often times a player can misinterpret a clue as a _Chop Move_ when it really had some other meaning. If this happens, after they discard their new _Chop_, everyone else on the team will know that an accidental _Chop Move_ has occurred.
 - Later on in the game, sometimes a player in this situation will realize that they have made a mistake by _Chop Moving_ earlier on. They might be tempted to shift their chop back to where it is supposed to be.
 - However, unless they discard a critical card (see the above section), players should **never undo a _Chop Move_**, because they could be discarding a now-critical card that was not critical at the time of the original mistake. Everyone else on the team did not bother to clue the now-critical card, because they thought it was safely _Chop Moved_.
+
+## Challenge Questions
+
+If you are new to level 4, see if you can complete [these challenge questions](challenge-questions/level-4.mdx).


### PR DESCRIPTION
This pull request suggests a Challenge Question for Level-4.

It illustrates a situation where, even though 1's are played from right to left at the start of the game, playing "fresh" 1's should take precedence over playing 1's from the starting hand. As a result, this performs an _Order Chop Move (OCM)_ on the very next player.

![image](https://github.com/user-attachments/assets/7f33e226-e3b4-4c2f-9ce4-4d749b356af8)
