### PR TITLE
Add ambiguous GD to level 10

### DIFF
--- a/docs/level-10.mdx
+++ b/docs/level-10.mdx
@@ -36,6 +36,7 @@ import DoubleGentlemanDiscard from "./level-10/double-gentleman-discard.yml";
 - Often times, doing a _Gentleman's Discard_ will delay things and cost the team _Tempo_. Thus, a _Gentleman's Discard_ that slows things down is only good if there is some other side benefit to offset the lost _Tempo_ (such as delaying the discard of a valuable card, for example).
 - Just like how _Prompts_ take precedence over _Finesses_, _Sarcastic Discards_ take precedence over _Gentleman's Discards_.
 - It is explicitly illegal to perform a _Gentleman's Discard_ with a 1 when the other two copies of that 1 are on two different _Finesse Positions_ at the same time.
+- In rare cases, Cathy may perform a _Gentleman's Discard_ on a card that appears to have multiple possible identities. Only the true identity is signaled to play.
 
 ### The Layered Gentleman's Discard
 
@@ -144,7 +145,3 @@ import DoubleGentlemanDiscard from "./level-10/double-gentleman-discard.yml";
   - Alice forgot that _Double Gentleman's Discards_ were expressly illegal because it is possible for players to have asymmetric information about the current game state.
 
 <DoubleGentlemanDiscard />
-
-- However, if Bob doesn't know that he has a red 2, but he _does_ see blue 2 on Alice's _Finesse Position_, he can again discard the 2.
-- Bob does't know whether this is a _Gentleman's Discard_ on red 2 or on blue 2, but it is definitely a _Gentleman's Discard_.
-- When Bob sees that red 2 is the card he discarded, he writes a card note of "r2" on Cathy's slot 1. No card notes are written on Alice's blue 2.

--- a/docs/level-10.mdx
+++ b/docs/level-10.mdx
@@ -144,3 +144,7 @@ import DoubleGentlemanDiscard from "./level-10/double-gentleman-discard.yml";
   - Alice forgot that _Double Gentleman's Discards_ were expressly illegal because it is possible for players to have asymmetric information about the current game state.
 
 <DoubleGentlemanDiscard />
+
+- However, if Bob doesn't know that he has a red 2, but he _does_ see blue 2 on Alice's _Finesse Position_, he can again discard the 2.
+- Bob does't know whether this is a _Gentleman's Discard_ on red 2 or on blue 2, but it is definitely a _Gentleman's Discard_.
+- When Bob sees that red 2 is the card he discarded, he writes a card note of "r2" on Cathy's slot 1. No card notes are written on Alice's blue 2.

--- a/docs/level-10.mdx
+++ b/docs/level-10.mdx
@@ -36,7 +36,7 @@ import DoubleGentlemanDiscard from "./level-10/double-gentleman-discard.yml";
 - Often times, doing a _Gentleman's Discard_ will delay things and cost the team _Tempo_. Thus, a _Gentleman's Discard_ that slows things down is only good if there is some other side benefit to offset the lost _Tempo_ (such as delaying the discard of a valuable card, for example).
 - Just like how _Prompts_ take precedence over _Finesses_, _Sarcastic Discards_ take precedence over _Gentleman's Discards_.
 - It is explicitly illegal to perform a _Gentleman's Discard_ with a 1 when the other two copies of that 1 are on two different _Finesse Positions_ at the same time.
-- In rare cases, Cathy may perform a _Gentleman's Discard_ on a card that appears to have multiple possible identities. Only the true identity is signaled to play.
+- In rare cases, players may perform a _Gentleman's Discard_ on a card that appears to have multiple possible identities. However, when this happens, **only** the card with the true identity is transferred.
 
 ### The Layered Gentleman's Discard
 


### PR DESCRIPTION
If Bob doesn't fully know the identity of his card, but all possible options are on other players' _Finesse Positions_, he may initiate a _Gentleman's Discard_ by discarding his card. This results in a single player blind playing their _Finesse Position_.