### PR TITLE
Adding Play Leftmost in the Prompt Section

### DIFF
--- a/docs/level-1.mdx
+++ b/docs/level-1.mdx
@@ -103,6 +103,7 @@ D2N --> D2NL;
 
 - A _Prompt_ is when you get a player to play a clued card that was previously unknown.
 - If the player **was already going to play** the card, then **it isn't a _Prompt_**. _Prompts_ can only be on cards that were not going to play otherwise.
+- If a player is _Prompted_ and there are multiple cards in their hand that the _Prompt_ could apply to, they should play the **leftmost**.
 - An example of a _Prompt_ can be found in the [beginner's guide](beginner/prompt.mdx).
 - For level 5 players, see the _[Prompts in Multi-Color Variants](level-5.mdx#prompts-in-multi-color-variants)_ section.
 


### PR DESCRIPTION
Played with a lvl 1 player who had restarted playing the game, they had read lvl 1 text in the Learning Path to brush up but made mistakes with prompts in their games because the lvl 1 text doesn't include the 'play leftmost' convention in the Prompt section.