### PR TITLE
Fixing contradictory statement between Brown's Tempo Clue Inversion & Mud Clues

### DIFF
--- a/docs/variant-specific/muddy-rainbow-cocoa-rainbow.mdx
+++ b/docs/variant-specific/muddy-rainbow-cocoa-rainbow.mdx
@@ -12,8 +12,8 @@ These conventions apply to any variant with a muddy rainbow suit (touched by eve
 
 ### Tempo Clues
 
-- Similar to brown cards, if a player gives a _Tempo Clue_ to a single muddy rainbow or cocoa rainbow card, it is never a _Tempo Clue Chop Move_. If a player gives a _Tempo Clue_ that touches multiple muddy rainbow or cocoa rainbow cards, it means only that the rightmost muddy rainbow or cocoa rainbow card is playable.
-- This is because it is fairly valuable to get muddy rainbow and cocoa rainbow cards out of the hand as soon as possible in case blocking cards are drawn.
+- Similar to brown cards, if a player gives a _Tempo Clue_ to a single muddy rainbow or cocoa rainbow card, it is never a _Tempo Clue Chop Move_. This is because it is fairly valuable to get muddy rainbow and cocoa rainbow cards out of the hand as soon as possible in case blocking cards are drawn.
+- If a player gives a _Tempo Clue_ that touches multiple muddy rainbow or cocoa rainbow cards, then it is a [_Mud Clue_](muddy-rainbow-cocoa-rainbow.mdx#mud-clues).
 
 ### Muddy Rainbow Saves
 

--- a/docs/variant-specific/muddy-rainbow-cocoa-rainbow.mdx
+++ b/docs/variant-specific/muddy-rainbow-cocoa-rainbow.mdx
@@ -12,7 +12,8 @@ These conventions apply to any variant with a muddy rainbow suit (touched by eve
 
 ### Tempo Clues
 
-- Similar to brown cards, if a player gives a _Tempo Clue_ to a single muddy rainbow or cocoa rainbow card, it is never a _Tempo Clue Chop Move_. This is because it is fairly valuable to get muddy rainbow and cocoa rainbow cards out of the hand as soon as possible in case blocking cards are drawn.
+- Similar to brown cards, if a player gives a _Tempo Clue_ to a single muddy rainbow or cocoa rainbow card, it is never a _Tempo Clue Chop Move_.
+  - This is because it is fairly valuable to get muddy rainbow and cocoa rainbow cards out of the hand as soon as possible in case blocking cards are drawn.
 - If a player gives a _Tempo Clue_ that touches multiple muddy rainbow or cocoa rainbow cards, then it is a [_Mud Clue_](muddy-rainbow-cocoa-rainbow.mdx#mud-clues).
 
 ### Muddy Rainbow Saves


### PR DESCRIPTION
The section Tempo Clues in Muddy/Cocoa Rainbow variant specific convention doc makes a false statement that when two or more muddy/cocoa rainbow cards are given a tempo clue, then the rightmost one plays. This is Brown's Tempo Clue Inversion, and is contradictory with Mud Clues.