### PR TITLE
Replacing Hard Color Bluff with CCP in Prism

### DIFF
--- a/docs/variant-specific/prism.mdx
+++ b/docs/variant-specific/prism.mdx
@@ -4,18 +4,10 @@ title: Prism
 
 These conventions apply to any variant with a prism suit.
 
-### Prism Hard Color Bluff (Two-Or-More-Away-From-Playable)
+### Cathy's Connecting Principle in Prism
 
-- For the purpose of _Finesses_, prism cards only "connect" if they are the next direct color.
-- Players can perform a _Bluff_ on a prism card with a color, as long as the focus of the clue is a valid _Bluff_ target and the color represents a prism card that is _two-or-more-away-from-playable_.
-- As a consequence of this, you can _Bluff_ a prism 1 by cluing a prism 3 (with color).
-- For example, in a 3-player game of _Prism (5 Suits)_:
-  - Nothing is played on the stacks.
-  - Alice clues green to Cathy, touching a prism 3 as a _Play Clue_.
-  - Bob blind-plays a prism 1 from his _Finesse Position_.
-  - From Cathy's perspective, she knows that prism 3 is green, and that since green clue connects to a prism 3, this could be a _Double Finesse_. (If this was a _Double Finesse_, then Cathy would be called on to blind-play the prism 2 from her own hand as a _Self Finesse_.)
-  - However, Cathy knows that _Prism Hard Color Bluffs_ take precedence over _Double Finesses_. The prism 1 would connect to yellow, but it does not connect to green. Thus, this is just a _Bluff_.
-  - Cathy marks her green card as either a green 2 (as a normal _Bluff_), a green 3 (as a _3 Bluff_), or a prism 3 (as a _Prism Hard Color Bluff_).
+- For the purpose of _Bluffs_ and _Finesses_, prism cards only "connect" to the next direct color clue. (Rank clues connect normally.)
+- Thus, it is possible for players to perform a [_Hard 3 Bluff_](level-13.mdx#the-hard-3-bluff) on a prism 1 by cluing color to prism 3.
 
 ### The Ambiguous Prism Tempo Clue
 

--- a/docs/variant-specific/prism.mdx
+++ b/docs/variant-specific/prism.mdx
@@ -6,7 +6,7 @@ These conventions apply to any variant with a prism suit.
 
 ### Cathy's Connecting Principle in Prism
 
-- For the purpose of _Bluffs_ and _Finesses_, prism cards only "connect" to the next direct color clue. (Rank clues connect normally.)
+- For the purpose of _Finesses_ abd _Bluffs_, prism cards only "connect" to the next direct color clue. (Rank clues connect normally.)
 - Thus, it is possible for players to perform a [_Hard 3 Bluff_](level-13.mdx#the-hard-3-bluff) on a prism 1 by cluing color to prism 3.
 
 ### The Ambiguous Prism Tempo Clue


### PR DESCRIPTION
Per discussion here (https://discord.com/channels/140016142600241152/1373755373458165930) it was felt that simply formalizing Cathy's Connecting Principle in Prism is enough to make a Hard 3 Bluff of prism 1 through a color clue possible, and so there is no need to make a new convention for it.