### PR TITLE
Update Pink Prompt Rank Exception

### DIFF
--- a/docs/variant-specific/pink.mdx
+++ b/docs/variant-specific/pink.mdx
@@ -75,7 +75,7 @@ These conventions apply to any variant with a pink (touched by all ranks) suit.
 ### The Pink Prompt Rank Exception
 
 - Normally, _Prompts_ take precedence over _Finesses_. This means that if a card in a player's hand has one or more positive clues on it that "match", they should never blind-play their _Finesse Position_ and instead play their leftmost clued card.
-- This rule does **not** apply to potential pink cards that only have a single rank clue on them (and the rank on them does not match the rank of the promised card). In this situation, players should prefer playing their _Finesse Position_ instead of playing the clued card.
+- This rule does **not** apply to potential pink cards that only have a single rank clue on them when the rank on them does not match the rank of the promised card. In this situation, players should prefer playing their _Finesse Position_ instead of playing the clued card.
 - For example, in a 3-player game:
   - All of the 2's are played on the stacks.
   - Alice clues pink to Cathy, touching a pink 4 on slot 1 as a _Play Clue_.


### PR DESCRIPTION
The parenthetical looks like a requirement for this exception, rather than a clarification of what comes before it. In that case, I prefer to avoid a parenthetical.