### PR TITLE
Adding missing removed convention to null

### DIFF
--- a/docs/variant-specific/null.mdx
+++ b/docs/variant-specific/null.mdx
@@ -30,6 +30,7 @@ These conventions apply to any variant with a null (touched by no clues) suit. T
   - _Play Clues_ with a number 5 (including on a previously clued 5)
   - The _5 Stall_
   - The _5 Pull_
+  - The _5 Number Ejection_
   - The _5 Number Discharge_
 - These moves are replaced with other things; see below.
   - Even in stalling situations (e.g. having 8 clues available), _5 Stalls_ are still turned off.


### PR DESCRIPTION
5NE obviously should also be listed here because 5DE is also listed