### PR TITLE
Fix typo, `b33` -> `b3`

### DIFF
--- a/docs/beginner/save-principle.mdx
+++ b/docs/beginner/save-principle.mdx
@@ -27,7 +27,7 @@ import SavePrinciple from "./save-principle/save-principle.yml";
   - If Alice clues number 3, it will violate _Good Touch Principle_ because it will touch the red 3 (and the red 3 is already played on the stacks).
   - Here, Alice knows that it is better to violate _Good Touch Principle_ than to lose the chance at a perfect score. Thus, Alice must choose between the lesser of two evils and decide between cluing blue and cluing number 3.
   - Alice decides to clue blue to Bob instead of number 3 because at least one of the blue 4's will be useful later on.
-  - Bob will write "b2, b33" on his saved card on slot 5. (From Bob's perspective, the card could be either a _Play Clue_ on blue 2, or a _Save Clue_ on blue 3.)
+  - Bob will write "b2, b3" on his saved card on slot 5. (From Bob's perspective, the card could be either a _Play Clue_ on blue 2, or a _Save Clue_ on blue 3.)
   - From _Good Touch Principle_, Bob will write "b2, b3, b4, b5" on his two other blue cards.
 
 <SavePrinciple />


### PR DESCRIPTION
Unless `b33` means something I am not aware of, I assume this was a typo.