### PR TITLE
Remove extra clue arrow from save-principle-answer-1.yml

### DIFF
--- a/docs/beginner/save-principle-question-1/save-principle-answer-1.yml
+++ b/docs/beginner/save-principle-question-1/save-principle-answer-1.yml
@@ -16,7 +16,6 @@ players:
   - clueGiver: true
     cards:
       - type: b
-        clue: b
         middleNote: b1
       - type: x
       - type: x


### PR DESCRIPTION
This old clue arrow is distracting from the clue that Bob actually just gave