### PR TITLE
Give [clued] note in level 10 Baton Discard

### DIFF
--- a/docs/level-10.mdx
+++ b/docs/level-10.mdx
@@ -66,7 +66,7 @@ import DoubleGentlemanDiscard from "./level-10/double-gentleman-discard.yml";
 
 <BatonDiscard />
 
-- Similar to the _Gentleman's Discard_, the transferred card counts as being clued. (All players should write a note of exactly the card transferred. For example, a note of "r3" would be written in the situation above.)
+- Similar to the _Gentleman's Discard_, the transferred card counts as being clued. (All players should write a note of exactly the card transferred. For example, a note of "[r3][clued]" would be written in the situation above.)
   - Subsequently, this means that the player's _Finesse Position_ will shift to the right by one slot.
 - Note that it is **illegal** to perform a _Layered Baton Discard_; the card **must** be exactly on _Finesse Position_.
   - This is because a _Layered Baton Discard_ would be information asymmetric. Since the card is not playable yet, the layer would not unravel in a defined time frame. In other words, if the card does not become playable for a long time, the player could technically discard the card without knowing that it was inside of a layer.


### PR DESCRIPTION
Because treating a card as clued modifies focus, it's important to actually get the arrows to change color