### PR TITLE
Simplify the process for determining clue focus

### DIFF
--- a/docs/beginner/single-card-focus.mdx
+++ b/docs/beginner/single-card-focus.mdx
@@ -20,14 +20,15 @@ import ChopFocus from "./single-card-focus/chop-focus.yml";
 - When determining the focus of a clue, you need to look for "new" cards.
 - New cards are specifically defined as **cards that are touched by a clue that did not have any clues "on" them already**.
 
-### Determining the Focus: 4 Steps
+### Determining the Focus
 
 So, when two or more cards are touched by a clue, which card is focused?
 
 1. If no cards are new, then **the focus is on the leftmost re-touched card**.
-1. If only one card is new, then **the focus is on the new card**.
-1. If two or more cards are new, and one of them was on chop, then **the focus is on the chop**.
-1. If two or more cards are new, and none of them were on chop, then **the focus is on the leftmost new card**.
+1. If the chop card was touched, then **the focus is on the chop**.
+   (This is still true even if other cards were touched in addition to
+   the chop!)
+1. Otherwise, **the focus is on the leftmost new card**.
 
 ### Example 1: Leftmost Focus
 

--- a/docs/level-1.mdx
+++ b/docs/level-1.mdx
@@ -38,12 +38,11 @@ title: Level 1 - Fundamentals
 
 ### Clue Focus
 
-There is a 4-step process for determining the focus of a clue:
+The process for determining the focus of a clue is as follows:
 
-1. If no cards are new, then **the focus is on the leftmost re-touched card**.
-1. If only one card is new, then **the focus is on the new card**.
-1. If two or more cards are new, and one of them was on chop, then **the focus is on the chop**.
-1. If two or more cards are new, and none of them were on chop, then **the focus is on the leftmost new card**.
+1. If no new cards were touched, then **the focus is on the leftmost re-touched card**.
+1. If the chop card was touched, then **the focus is on the chop**.
+1. Otherwise, **the focus is on the leftmost newly touched card**.
 
 This process is represented in the following flowchart:
 


### PR DESCRIPTION
When I was first learning level 1 I found the description of determining clue focus quite confusing.  Saying it was a "4-step process" and talking about whether there were multiple new cards touched or not seemed unnecessarily complicated, but it took me a while to untangle and make sure I was understanding it properly.  The flowchart that's already there in the level 1 document is actually perfect --- this PR just changes the textual description of the process to match, in both level 1 and the beginner's guide (with an extra warning in the beginner's guide that there could be other new cards touched in addition to the chop).