### PR TITLE
Update special-fives.mdx

### DIFF
--- a/docs/variant-specific/special-fives.mdx
+++ b/docs/variant-specific/special-fives.mdx
@@ -13,12 +13,6 @@ These conventions apply to the "Special-Fives" variants (e.g. "Pink-Fives", "Mud
 
 - Even though fives have a true color, players are not expected to use the matching color when touching them.
 
-### The Color Promise Finesse (Level 20+)
-
-- What if _Color Promise_ is violated and the clue is only a 1-for-1? The clue giver must be trying to communicate something extra.
-- In this situation, the next player should blind-play their _Finesse Position_ card as a _Color Promise Finesse_.
-- Note that the _Color Promise Finesse_ can only be performed if the card that is blind-played connects to the clue that was given. Otherwise, Cathy will think that a _Bluff_ happened and will not play the clued card.
-
 ### Mud Clues
 
 - [_Mud Clues_](muddy-rainbow-cocoa-rainbow.mdx#mud-clues) (from muddy rainbow variants) also apply to rainbow-fives.

--- a/docs/variant-specific/special-fives.mdx
+++ b/docs/variant-specific/special-fives.mdx
@@ -9,9 +9,9 @@ These conventions apply to the "Special-Fives" variants (e.g. "Pink-Fives", "Mud
 
 ## Rainbow-Fives
 
-### Color Promise
+### No Color Promise
 
-- When giving a color clue to a rainbow-five, it's nice to inform the receiver of the color identity, so we try to give this when possible.
+- Even though fives have a true color, players are not expected to use the matching color when touching them.
 
 ### The Color Promise Finesse (Level 20+)
 

--- a/docs/variant-specific/special-fives.mdx
+++ b/docs/variant-specific/special-fives.mdx
@@ -11,22 +11,11 @@ These conventions apply to the "Special-Fives" variants (e.g. "Pink-Fives", "Mud
 
 ### Color Promise
 
-- When giving a color clue to a rainbow-five, you are expected to use the color that matches the card.
-- There are two exceptions, which are listed below.
+- When giving a color clue to a rainbow-five, it's nice to inform the receiver of the color identity, so we try to give this when possible.
 
-### The Color Play Clue Lie
+### The Color Promise Finesse (Level 20+)
 
-- First, see the section on the _[Pink Play Clue Lie](pink.mdx#the-pink-play-clue-lie-ppcl-with-a-mismatched-play-clue-that-touches-other-cards)_ (for pink variants).
-- Similar to how the _Pink Play Clue Lie_ violates _Pink Promise_, you can do a _Color Play Clue Lie_ to violate _Color Promise_ in the same way.
-- In other words, you can break _Color Promise_ if and only if:
-  - using a "wrong" color would get extra cards in the same hand as part of the same clue (e.g. a 2-for-1 on red 5 & blue 2 instead of a 1-for-1 on red 5)
-  - the card would play immediately or very soon
-  - no-one else would be confused
-
-### The Color Promise Finesse
-
-- First, see the section on the _[Color Play Clue Lie](#the-color-play-clue-lie)_.
-- Usually, when _Color Promise_ is violated, it is a _Color Play Clue Lie_. But what if _Color Promise_ is violated and the clue is only a 1-for-1? The clue giver must be trying to communicate something extra.
+- What if _Color Promise_ is violated and the clue is only a 1-for-1? The clue giver must be trying to communicate something extra.
 - In this situation, the next player should blind-play their _Finesse Position_ card as a _Color Promise Finesse_.
 - Note that the _Color Promise Finesse_ can only be performed if the card that is blind-played connects to the clue that was given. Otherwise, Cathy will think that a _Bluff_ happened and will not play the clued card.
 


### PR DESCRIPTION
* color promise not required while still encouraged
* color play clue lie implicitly allowed now
* color Promise Finesse turned on same level as other suboptimal finesse/bluffs are enabled in the main convention